### PR TITLE
Add unbolded text across all of Scratch

### DIFF
--- a/extras/stsettings.js
+++ b/extras/stsettings.js
@@ -84,7 +84,7 @@ featured.textContent = 'New Features'
 
 document.querySelector('#page-404 > div').appendChild(featured)
 
-createFeature('Unbold Forum Topics', 'Make it so that the titles of forum topics will no longer be bolded, giving a calmer feeling to the discuss page.', 'unbold-forum-topics')
+createFeature('Unbold Site Text', 'Makes it so that all test across Scratch is unbolded, and just normal text!', 'unbold-forum-topics')
 
 
 var br = document.createElement('br')

--- a/features/unbold-forum-topics.js
+++ b/features/unbold-forum-topics.js
@@ -1,21 +1,9 @@
-// get cookie
-function getCookie(name) {
-    const value = `; ${document.cookie}`;
-    const parts = value.split(`; ${name}=`);
-    if (parts.length === 2) return parts.pop().split(';').shift();
-  }
-  // get cookie
-
-      if (getCookie('ST Features').includes('unbold-forum-topics')) {
-if (window.location.href.includes('https://scratch.mit.edu/discuss/')) {
-    if (!window.location.href.includes('topic')) {
-document.querySelectorAll('a').forEach(function(el) {
-    if (el.href !== null) {
-        if (el.href.includes('https://scratch.mit.edu/discuss/topic/')) {
-            el.style.fontWeight = 'normal'
-        }
-    }
+function unbold() {
+    if (window.location.href.includes('https://scratch.mit.edu/')) {
+document.querySelectorAll('*').forEach(function(el) {
+    el.style.fontWeight = 'normal'
 })
+        window.setTimeout(unbold, 100)
 }
 }
-}
+unbold()


### PR DESCRIPTION
Thanks to @Scratchfangs for the suggestion!!

This changes the forum unbolded to unbolded text across ALL of Scratch!
<img width="1395" alt="Screen Shot 2022-05-04 at 8 24 09 PM" src="https://user-images.githubusercontent.com/86856959/166859461-3454029e-2035-4716-9f03-ad3bbf2e1ebd.png">
As you can see, it looks smoother.