### PR TITLE
Fix Duplicating Recently Viewed Projects Tab

### DIFF
--- a/features/recently-viewed-projects.js
+++ b/features/recently-viewed-projects.js
@@ -7,7 +7,7 @@ li.appendChild(a)
   li.dataset.tab = 'recent'
 document.querySelector('ul#tabs').lastChild.className = ''
 li.className = 'last'
-if (document.querySelector('a.recent-scratchtools') === undefined) {
+if (document.querySelector('a.recent-scratchtools') === null) {
 document.querySelector('ul#tabs').appendChild(li)
 }
 li.onclick = function() {

--- a/features/recently-viewed-projects.js
+++ b/features/recently-viewed-projects.js
@@ -2,11 +2,14 @@
 var li = document.createElement('li')
 var a = document.createElement('a')
 a.textContent = 'Recently Viewed'
+a.className = 'recent-scratchtools'
 li.appendChild(a)
   li.dataset.tab = 'recent'
 document.querySelector('ul#tabs').lastChild.className = ''
 li.className = 'last'
+if (document.querySelector('a.recent-scratchtools') === undefined) {
 document.querySelector('ul#tabs').appendChild(li)
+}
 li.onclick = function() {
     getRecent()
 }


### PR DESCRIPTION
If you switch between tabs multiple times in my stuff, the recently viewed projects tab duplicates each time. This fix will include using a specific class name for the tab and querySelector to make sure that it does not create a new tab if one already exists.