### PR TITLE
Fix Font Bug

### DIFF
--- a/extras/stsettings.css
+++ b/extras/stsettings.css
@@ -1,3 +1,9 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk&display=swap');
+
+body {
+    font-family: 'Space Grotesk', sans-serif;
+}
+
 .switch {
     position: relative;
     display: inline-block;
@@ -79,5 +85,5 @@ h3 {
   }
 
   h1, h2, h3, h4, h5, h6 {
-    font-family: Roboto;
+    font-family: 'Space Grotesk', sans-serif;
   }


### PR DESCRIPTION
The CSS file for the settings popup used to try using a font (Roboto) that the popup didn't have access to. We have now changed the font to Space Grotesk and added access to it in the `stsettings.css` file.