### PR TITLE
New API

### DIFF
--- a/api/logging.js
+++ b/api/logging.js
@@ -1,0 +1,24 @@
+function logTool(text) {
+    var styleArray= [
+        'padding: 0.1rem',
+      'border : 0.1rem solid lime',
+        'border-radius: 0.2rem'
+    ];
+    console.log('%cScratchTools', styleArray.join(';'), text);
+}
+function warnTool(text) {
+  var styleArray= [
+      'padding: 0.1rem',
+    'border : 0.1rem solid yellow',
+      'border-radius: 0.2rem'
+  ];
+  console.log('%cScratchTools', styleArray.join(';'), text);
+}
+function errorTool(text) {
+  var styleArray= [
+      'padding: 0.1rem',
+    'border : 0.1rem solid #ff9f00',
+      'border-radius: 0.2rem'
+  ];
+  console.log('%cScratchTools', styleArray.join(';'), text);
+}

--- a/api/vm.js
+++ b/api/vm.js
@@ -1,0 +1,30 @@
+try {
+var vm = window.vm || (() => {
+    const app = document.querySelector("#app");
+    return app[Object.keys(app).find(key => key.startsWith("__reactContainer"))].child.stateNode.store.getState().scratchGui.vm;
+})();
+logTool("Loaded VM.")
+    if (Blockly === undefined) {
+        logTool("Loaded Blockly.")
+    } else {
+        warnTool("Could not load Blockly.")
+    }
+} catch(err) {
+    warnTool("Could not load VM.")
+    try {
+    if (Blockly === undefined) {
+        logTool("Loaded Blockly.")
+    } else {
+        warnTool("Could not load Blockly.")
+    }
+} catch(err) {
+    warnTool("Could not load Blockly.")
+}
+}
+function ScratchTools() {
+    var vm = window.vm || (() => {
+        const app = document.querySelector("#app");
+        return app[Object.keys(app).find(key => key.startsWith("__reactContainer"))].child.stateNode.store.getState().scratchGui.vm;
+    })();
+    return({"vm":vm, "blockly":Blockly.getMainWorkspace()})
+}

--- a/extras/background.js
+++ b/extras/background.js
@@ -8,6 +8,16 @@ chrome.runtime.onInstalled.addListener(() => { // this event is triggered when t
     var response = await fetch('/features/features.json')
     var data = await response.json()
     console.log(data)
+    chrome.scripting.executeScript({
+      target: { tabId: tabId },
+      files: [`/api/logging.js`],
+      world:'MAIN'
+    });
+    chrome.scripting.executeScript({
+      target: { tabId: tabId },
+      files: [`/api/vm.js`],
+      world:'MAIN'
+    });
     Object.keys(data).forEach(async function(el) {
       chrome.storage.sync.get("features", function (obj) {
         console.log(obj['features']);
@@ -16,14 +26,16 @@ chrome.runtime.onInstalled.addListener(() => { // this event is triggered when t
           if (!obj['features'].includes(data[el]['file'])) {
        chrome.scripting.executeScript({
         target: { tabId: tabId },
-        files: [`/features/${data[el]['file']}.js`]
+        files: [`/features/${data[el]['file']}.js`],
+        world:'MAIN'
       });
     }
         } else {
         if (obj['features'].includes(data[el]['file'])) {
        chrome.scripting.executeScript({
         target: { tabId: tabId },
-        files: [`/features/${data[el]['file']}.js`]
+        files: [`/features/${data[el]['file']}.js`],
+        world:'MAIN'
       });
         }
     }
@@ -46,4 +58,3 @@ chrome.runtime.onInstalled.addListener(() => { // this event is triggered when t
   getCurrentTab()
   }
   })
-  


### PR DESCRIPTION
This only involves the changes of a few files, but adds a lot more:
- Features can now access the VM and Blockly using `ScratchTools().vm` or `ScratchTools().blockly`.
- There are now loggings, warnings, and error logs specific to ScratchTools that can easily be used like this: `logTool()`, `warnTool()`, `errorTool()`- they are already used for Blockly and VM loading.

This unlocks dozens of possibilities for ScratchTools, as we haven't really entered into the world of editor tools. This will let us do so, and make it easy for developers to integrate the APIs into their features.