### PR TITLE
Fixed vm from API change

### DIFF
--- a/features/delete-all.js
+++ b/features/delete-all.js
@@ -21,7 +21,7 @@ checkForContextMenu()
 function deleteAllSprites() {
     ScratchTools.Scratch.vm.runtime.targets.forEach(function(el) {
         if (!el.isStage) {
-            vm.deleteSprite(el.id)
+            ScratchTools.Scratch.vm.deleteSprite(el.id)
         }
     })
 }

--- a/features/last-key-pressed.js
+++ b/features/last-key-pressed.js
@@ -4,7 +4,7 @@ function addKeyPressed() {
     lkp.className = 'scratchtools key share-date'
     if (document.querySelector('div.scratchtools.key') === null) {
         document.querySelector('div.flex-row.subactions').prepend(lkp)
-        vm.runtime.on('KEY_PRESSED', function(el) {
+        ScratchTools.Scratch.vm.runtime.on('KEY_PRESSED', function(el) {
             if (document.querySelector('div.scratchtools.key') !== null) {
                 document.querySelector('div.scratchtools.key').textContent = 'Last Key Pressed: ' + el
             }
@@ -24,7 +24,7 @@ function addKeyPressedEditor() {
                 el.firstChild.appendChild(div)
             }
         })
-        vm.runtime.on('KEY_PRESSED', function(el) {
+        ScratchTools.Scratch.vm.runtime.on('KEY_PRESSED', function(el) {
             if (document.querySelector('div.scratchtools.navlastkey') !== null) {
                 document.querySelector('div.scratchtools.navlastkey').querySelector('span').textContent = 'Last Key Pressed: ' + el
             }

--- a/features/project-timer.js
+++ b/features/project-timer.js
@@ -1,19 +1,19 @@
 if (window.location.href.includes('https://scratch.mit.edu/projects/')) {
 var times = []
 var stop = []
-vm.runtime.on('PROJECT_RUN_START', function() {
+ScratchTools.Scratch.vm.runtime.on('PROJECT_RUN_START', function() {
     times = []
     stop = []
-    times.push(vm.runtime.currentMSecs)
+    times.push(ScratchTools.Scratch.vm.runtime.currentMSecs)
     getCurrentM()
 })
-vm.runtime.on('PROJECT_RUN_STOP', function() {
+ScratchTools.Scratch.vm.runtime.on('PROJECT_RUN_STOP', function() {
     stop.push('')
 })
 function getCurrentM() {
     if (stop.length === 0) {
-    if ((vm.runtime.currentMSecs-times[times.length-1])/1000 !== NaN) {
-    document.querySelector('div.timer.scratchtools').textContent = `${(vm.runtime.currentMSecs-times[times.length-1])/1000} secs`
+    if ((ScratchTools.Scratch.vm.runtime.currentMSecs-times[times.length-1])/1000 !== NaN) {
+    document.querySelector('div.timer.scratchtools').textContent = `${(ScratchTools.Scratch.vm.runtime.currentMSecs-times[times.length-1])/1000} secs`
     setTimeout(getCurrentM, 50)
     }
     }


### PR DESCRIPTION
When the API for vm and blockly were changed, vm on its own was no longer defined, and so multiple features (project timer, last key pressed, and delete all sprites) were broken.