### PR TITLE
Fix collapse blocks causing variable blocks to break

### DIFF
--- a/features/collapse-blocks.js
+++ b/features/collapse-blocks.js
@@ -10,6 +10,7 @@ function addCollapse() {
 try {
 Object.keys(ScratchTools.Scratch.blockly.getMainWorkspace().blockDB_).forEach(function(id) {
     var block = ScratchTools.Scratch.blockly.getMainWorkspace().getBlockById(id)
+    if (block.outputShape_ === null) {
     if (Window.collapsed.includes(id)) {
         block.setCollapsed(true)
     } else {
@@ -31,6 +32,7 @@ var collapse = {"enabled":true, "text":"Uncollapse"}
     }
     el.push(collapse)
 }
+    }
 })
 } catch(err) {
     ScratchTools.console.error(err)


### PR DESCRIPTION
The new collapse block feature removes the ability for you to right-click a variable to switch it. The feature would also break input blocks. As there is little to no point in collapsing an input block, we removed the ability to collapse input blocks to solve this issue.