### PR TITLE
Sprite list

### DIFF
--- a/features/features.json
+++ b/features/features.json
@@ -9,6 +9,15 @@
 		"type": ["Editor"]
 	},
 	{	
+		"title": "Sprite List",
+		"description": "Replaces the sprite grid in the editor with a list that includes the block count and position of the sprite.",
+		"credits": ["rgantzos"],
+		"urls": ["https://scratch.mit.edu/users/rgantzos/"],
+		"file": "list-sprites",
+		"tags": ["New", "Beta"],
+		"type": ["Editor"]
+	},
+	{	
 		"title": "Link Users in Forum Activity",
 		"description": "In the forums' last post section, makes the usernames link to the user's profile.",
 		"credits": ["-KittyStudios-", "rgantzos"],

--- a/features/list-sprites.js
+++ b/features/list-sprites.js
@@ -1,0 +1,36 @@
+if (window.location.href.includes('/editor') && window.location.href.startsWith('https://scratch.mit.edu/projects/')) {
+    function setStuff() {
+        try {
+        var base
+        document.querySelectorAll('div').forEach(function(el) {
+            if (el.className.startsWith('sprite-selector_items-wrapper_') && el.className.includes(' box_box_')) {
+                base = el
+            }
+        })
+        var children = []
+        base.querySelectorAll('div').forEach(function(el) {
+            if (el.className.startsWith('sprite-selector_sprite-wrapper_')) {
+                    children.push(el)
+            }
+        })
+        children.forEach(function(el) {
+            el.style.width = '100%'
+            el.firstChild.style.width = '100%'
+            el.style.maxWidth = '100%'
+            el.firstChild.style.textAlign = 'left'
+            var title
+            el.querySelectorAll('div').forEach(function(element) {
+                if (element.className.startsWith('sprite-selector-item_sprite-name_')) {
+                    title = element
+                }
+            })
+            if (!el.className.includes(' scratchtoolswide')) {
+            title.id = title.textContent
+            el.className = el.className+' scratchtoolswide'
+            }
+            title.textContent = title.id+' ('+Object.keys(ScratchTools.Scratch.vm.runtime.getSpriteTargetByName(title.id).blocks._blocks).length+' blocks) ('+ScratchTools.Scratch.vm.runtime.getSpriteTargetByName(title.id).x.toString()+', '+ScratchTools.Scratch.vm.runtime.getSpriteTargetByName(title.id).y+')'
+        })
+    } catch(err) {}
+        }
+        setInterval( setStuff , 50 )
+}


### PR DESCRIPTION
![Screen Shot 2022-07-30 at 5 55 17 PM](https://user-images.githubusercontent.com/86856959/182005114-37461477-436f-4847-bf56-bf08149d24e4.png)
Replaces the sprite grid with a list of the sprites- each one also displays its own block count and position.