### PR TITLE
Scrollable list items

### DIFF
--- a/features/features.json
+++ b/features/features.json
@@ -1,5 +1,14 @@
 [
 	{	
+		"title": "Scrollable List Items",
+		"description": "List items that have a value longer than the width of the list itself will get cut off. Now, you can scroll left and right through the list item.",
+		"credits": ["rgantzos", "philipp2007"],
+		"urls": ["https://scratch.mit.edu/users/rgantzos/", "https://scratch.mit.edu/users/philipp2007/"],
+		"file": "scrollable-list-items",
+		"tags": ["New", "Recommended"],
+		"type": ["Website", "Editor"]
+	},
+	{	
 		"title": "Sprite Clone Counter",
 		"description": "Displays the clone count for each individual sprite.",
 		"credits": ["rgantzos", "GrahamBurger"],

--- a/features/scrollable-list-items.js
+++ b/features/scrollable-list-items.js
@@ -1,0 +1,10 @@
+if (window.location.href.startsWith('https://scratch.mit.edu/projects/')) {
+var style = document.createElement('style')
+style.innerHTML = `
+.monitor_value-inner_3E9Ou {
+    overflow: scroll;
+    text-overflow: clip;
+}
+`
+document.body.appendChild(style)
+}


### PR DESCRIPTION
If you have an item in a list that's longer than the width of the list itself, it's a pain to try and read it. You have to copy it, and then past it somewhere, and then go back to the editor, and so on.

Now, you can scroll left and right through individual list items!