### PR TITLE
Update context menu API name

### DIFF
--- a/api/vm.js
+++ b/api/vm.js
@@ -24,7 +24,7 @@ try {
 
 ScratchTools.Scratch.contextMenus = {}
 
-ScratchTools.Scratch.addContextMenu = function(info) {
+ScratchTools.Scratch.waitForContextMenu = function(info) {
     if (ScratchTools.Scratch.contextMenus[info.block] !== undefined) {
         ScratchTools.Scratch.contextMenus[info.block][info.id] = info.callback
     } else {

--- a/features/collapse-blocks.js
+++ b/features/collapse-blocks.js
@@ -34,7 +34,7 @@ var collapse = {"enabled":true, "text":"Uncollapse"}
     }
     el.push(collapse)
 }
-ScratchTools.Scratch.addContextMenu({"block":block.id,"id":"collapse-blocks","callback":test})
+ScratchTools.Scratch.waitForContextMenu({"block":block.id,"id":"collapse-blocks","callback":test})
     }
 })
 } catch(err) {


### PR DESCRIPTION
To prevent confusion, changes the context menu API name from addContextMenu to waitForContextMenu.