### PR TITLE
Fix key codes for block log

### DIFF
--- a/features/block-log.js
+++ b/features/block-log.js
@@ -5,7 +5,7 @@ document.addEventListener('keydown', function(event) {
     keydown(event)
 
     function keydown(e) {
-        if (e.keyCode == 76 && e.shiftKey) {
+        if (e.keyCode == 76 && e.shiftKey && e.ctrlKey) {
             if (document.querySelector('#mydiv') === null) {
             addProjectLog()
             } else {


### PR DESCRIPTION
Right now, all you have to press is shift+l for the block log to appear, when it should be ctrl+shift+l. Not only does this make the feature description incorrect, but it also makes it impossible to type an uppercase l without opening the block log.