### PR TITLE
Delete custom block uses

### DIFF
--- a/features/delete-custom-block-uses.js
+++ b/features/delete-custom-block-uses.js
@@ -1,0 +1,34 @@
+if (window.location.href.startsWith('https://scratch.mit.edu/projects/') && window.location.href.includes('/editor')) {
+function addCustomBlockCode() {
+    try {
+    Object.keys(ScratchTools.Scratch.blockly.getMainWorkspace().blockDB_).forEach(function(el) {
+    var block = ScratchTools.Scratch.blockly.getMainWorkspace().getBlockById(el)
+        if (block.type === "procedures_prototype") {
+    var callback = function(el) {
+        var deleteCustomBlocks = {"enabled":true, "text":"Delete All Uses"}
+        deleteCustomBlocks.callback = function() {
+            if (confirm("Are you sure you want do do this? It will delete all instances of this block, along with the blocks below it in some cases.")) {
+            Object.keys(ScratchTools.Scratch.blockly.getMainWorkspace().blockDB_).forEach(function(newBlockId) {
+                var newBlock = ScratchTools.Scratch.blockly.getMainWorkspace().getBlockById(newBlockId)
+                if (newBlock.type === "procedures_call") {
+                if (newBlock.getProcCode() === block.getProcCode()) {
+                    newBlock.dispose()
+                }
+                }
+            })
+            alert("Deleted all instances of the "+block.getProcCode()+" custom block.")
+        } else {
+            alert("Canceled.")
+        }
+        }
+        el.push(deleteCustomBlocks)
+    }
+    ScratchTools.Scratch.waitForContextMenu({"block":block.parentBlock_.id,"id":"delete-custom-blocks","callback":callback})
+        }
+    })
+} catch(err) {}
+    }
+    
+    var waitForNewCustomBlocks = new MutationObserver(addCustomBlockCode);
+    waitForNewCustomBlocks.observe(document.querySelector('body'), { attributes: true, childList: true, subtree: true });
+}

--- a/features/features.json
+++ b/features/features.json
@@ -1,5 +1,14 @@
 [
 	{	
+		"title": "Delete Custom Block",
+		"description": "To delete a custom block, you must remove all of it's uses. Now, you can Right Click > Delete All Uses on a custom block to delete all of it's uses. This will delete all blocks below the custom block in scripts.",
+		"credits": ["rgantzos"],
+		"urls": ["https://scratch.mit.edu/users/rgantzos/"],
+		"file": "delete-custom-block-uses",
+		"tags": ["New", "Beta"],
+		"type": ["Editor"]
+	},
+	{	
 		"title": "Sprite Clone Counter",
 		"description": "Displays the clone count for each individual sprite.",
 		"credits": ["rgantzos", "GrahamBurger"],


### PR DESCRIPTION
I find it so annoying when i'm trying to delete a custom block but i have to go through and delete each place where the block is. Now, ScratchTools can do it for you.

Also, to make sure you don't do it by accident, it adds a confirmation.