### PR TITLE
Fix default to local not working with other languages

### DIFF
--- a/features/default-to-local.js
+++ b/features/default-to-local.js
@@ -1,5 +1,5 @@
 ScratchTools.waitForElements('.ReactModalPortal', function(el) {
-    if (el.querySelector('[aria-label="New Variable"]')) {
-        document.querySelector('input[value="local"]').click()
+    if (el.querySelector('[class^="prompt_variable-name-text-input_"]')) {
+        document.querySelectorAll('[name="variableScopeOption"]')[1].click()
     }
 }, 'default local', false)


### PR DESCRIPTION
Currently, default to local doesn't work if your language isn't English due to values of the inputs. This changes the method when it comes to checking so that it isn't dependent on language.