### PR TITLE
Fix radiuses for left side stage

### DIFF
--- a/features/left-side-stage.js
+++ b/features/left-side-stage.js
@@ -23,6 +23,20 @@ if (!document.querySelector(".scratchtoolsLeftSideStage")) {
       margin-left: 0 !important;
       margin-right: calc(0.5rem / 2) !important;
     }
+.injectionDiv {
+    border-top-right-radius: 0px !important;
+    border-bottom-left-radius: .5rem !important;
+    border-bottom-right-radius: 0px !important;
+}
+
+div[class^="gui_extension-button-container_"] {
+    border-bottom-left-radius: .5rem !important;
+}
+
+[class^="backpack_backpack-header_"] {
+    border-top-right-radius: 0px !important;
+    border-top-left-radius: .5rem !important;
+}
     `);
   style.className = "scratchtoolsLeftSideStage";
 


### PR DESCRIPTION
Fixes the rounded and unrounded borders that should be the opposite when left-side stage is enabled.

![image](https://user-images.githubusercontent.com/86856959/200150685-26bef531-8860-4003-be84-4c09982a2571.png)
![image](https://user-images.githubusercontent.com/86856959/200150687-91926eaf-04e8-413e-9e2d-2f8bb99b76b7.png)
![image](https://user-images.githubusercontent.com/86856959/200150689-9189aa5e-96b3-41c2-b248-798800d62858.png)
becomes this
<img width="1440" alt="Screenshot 2022-11-05 at 7 08 24 PM" src="https://user-images.githubusercontent.com/86856959/200150715-3abf6aea-a700-4598-adcf-baa431617f2e.png">
