### PR TITLE
Stop fetching from ScratchTools website

### DIFF
--- a/extras/background.js
+++ b/extras/background.js
@@ -229,7 +229,7 @@ chrome.alarms.onAlarm.addListener(async function () {
     delayInMinutes: 0.1,
     periodInMinutes: 0.1,
   });
-  var response = await fetch("https://scratchtools.app/disabled/");
+  var response = await fetch("https://raw.githubusercontent.com/STForScratch/data/main/disabled.json");
   var data = await response.json();
   await chrome.storage.sync.set({ autoDisabled: data });
   var obj = await chrome.storage.sync.get("features");

--- a/extras/popup.js
+++ b/extras/popup.js
@@ -817,7 +817,7 @@ if (document.querySelector("h2.feedback") !== null) {
 
 async function getNews() {
   try {
-    var response = await fetch("https://scratchtools.app/news/");
+    var response = await fetch("https://raw.githubusercontent.com/STForScratch/data/main/news.json");
     var data = await response.json();
     data.forEach(function (el) {
       var div = document.createElement("div");

--- a/features/features.json
+++ b/features/features.json
@@ -255,20 +255,6 @@
     "dynamic": true
   },
   {
-    "title": "Open Project as Javascript",
-    "description": "Easily open any Scratch project in a Javascript editor!",
-    "credits": ["PullJosh", "maDU59"],
-    "urls": [
-      "https://scratch.mit.edu/users/PullJosh/",
-      "https://github.com/maDU59"
-    ],
-    "file": "leopard",
-    "tags": ["Featured"],
-    "type": ["Editor"],
-    "dynamic": true,
-    "warning": "The button is no longer in the navbar, it is now in the File dropdown menu."
-  },
-  {
     "title": "Online Scratchers in Multiplayer Game",
     "description": "On project pages, displays all of the Scratchers currently in that multiplayer game.",
     "credits": ["rgantzos"],

--- a/features/nfe-project-checker.js
+++ b/features/nfe-project-checker.js
@@ -3,12 +3,7 @@ function check() {
     window.setTimeout(check, 50);
   } else {
     async function checkforNfe() {
-      var response = await fetch(
-        `https://scratchtools.app/nfe/${
-          window.location.href.split("/projects/")[1].split("/")[0]
-        }/`
-      );
-      var data = await response.json();
+      var data = await getStatus(window.location.href.split("/projects/")[1].split("/")[0])
       var date = document.querySelector("div.share-date").lastChild;
       if (!date.className.includes("scratchtools")) {
         if (data["status"] === "notreviewed") {
@@ -29,3 +24,9 @@ function check() {
   }
 }
 check();
+
+async function getStatus(project) {
+  var response = await fetch('https://scratch.mit.edu/projects/'+project+'/remixtree/bare/')
+  var data = await response.json()
+  return data[project].moderation_status
+}

--- a/features/pause-audio.js
+++ b/features/pause-audio.js
@@ -15,7 +15,7 @@ if (window.location.href.startsWith("https://scratch.mit.edu/projects/")) {
           btn2.style.backgroundColor = "#ff9f00";
           btn2.style.marginLeft = ".5rem";
           var img = document.createElement("img");
-          img.src = "https://scratchtools.app/pause.svg";
+          img.src = "https://raw.githubusercontent.com/STForScratch/data/main/pause.svg";
           img.draggable = false;
           if (!ScratchTools.Scratch.scratchSound().state.playhead) {
             btn2.style.opacity = "0.5";


### PR DESCRIPTION
Currently, the ScratchTools website is slowing down severely because the userbase is growing quickly, but the site can't handle all the requests it is being sent (especially now that every page load now requests data).

This will stop sending image and API requests to the ScratchTools website, that way we can better assess the situation and determine whether or not we want to start using GitHub pages.