### PR TITLE
exact join date

### DIFF
--- a/features/exact-join-date.js
+++ b/features/exact-join-date.js
@@ -1,0 +1,22 @@
+async function getExactJoinDate(el) {
+  if (!el.className.includes("scratchtoolsUpdateTime")) {
+    el.classList.add("scratchtoolsUpdateTime");
+    var response = await fetch(
+      "https://api.scratch.mit.edu/users/" +
+        Scratch.INIT_DATA.PROFILE.model.username +
+        "/"
+    );
+    var data = await response.json();
+    el.childNodes[3].textContent = new Date(
+      data.history.joined
+    ).toLocaleString();
+    el.childNodes[4].textContent = "";
+  }
+}
+
+ScratchTools.waitForElements(
+  ".profile-details",
+  getExactJoinDate,
+  "get-exact-join-date",
+  false
+);

--- a/features/features.json
+++ b/features/features.json
@@ -1,5 +1,16 @@
 [
   {
+    "title": "Exact Join Date",
+    "description": "Displays the exact time that a user joined, shown on their profile.",
+    "credits": ["rgantzos"],
+    "urls": [
+      "https://scratch.mit.edu/users/rgantzos"
+    ],
+    "file": "exact-join-date",
+    "type": ["Website"],
+    "tags": ["New"]
+  },
+  {
     "title": "Direct image uploads in the forums",
     "description": "Allows you to easily upload images to the Scratch forums for posts and signatures without having to use third party image uploading services.",
     "credits": ["ISTILLMAKESTUFF", "TheGlassPenguin", "StickFireGames"],


### PR DESCRIPTION
displays the exact time and date that you joined, right on your profile
<img width="366" alt="Screenshot 2022-12-26 at 8 53 10 PM" src="https://user-images.githubusercontent.com/86856959/209613079-5cc0f9d7-7598-4775-9c95-23f5e7db7598.png">
