### PR TITLE
Add styles API

### DIFF
--- a/api/main.js
+++ b/api/main.js
@@ -160,3 +160,15 @@ function GM_addStyle(styleData) {
   style.textContent = styleData;
   return document.querySelector("html").appendChild(style);
 }
+
+ScratchTools.styles = {
+  add: function(data, id) {
+    var style = document.createElement("style")
+    style.textContent = data
+    if (id) {
+      style.dataset.scratchtoolsstyleid = id
+    }
+    document.body.after(style)
+    return style
+  }
+}


### PR DESCRIPTION
Adds `ScratchTools.styles.add()`. More can be added in the future. It includes the content parameter as well as an id, which is added to the element's dataset when created.