### PR TITLE
Unlisted project links

### DIFF
--- a/features/features.json
+++ b/features/features.json
@@ -1,16 +1,15 @@
 [
   {
     "title": "Unlisted Projects",
-    "description": "Hover over any username on the website to display the profile picture, username and follower count.",
-    "credits": ["Bingus the Bingus", "rgantzos"],
+    "description": "Allows you to generate share links for unshared projects in the editor.",
+    "credits": ["rgantzos"],
     "urls": [
-      "https://scratch.mit.edu/users/JefferyTheSuperKat/",
       "https://scratch.mit.edu/users/rgantzos"
     ],
     "file": "unlisted-projects",
-    "type": ["Website"],
+    "type": ["Editor"],
     "tags": ["New", "Recommended"],
-    "dynamic": true
+    "dynamic": false
   },
   {
     "title": "Search Context Menus",

--- a/features/features.json
+++ b/features/features.json
@@ -1,5 +1,18 @@
 [
   {
+    "title": "Unlisted Projects",
+    "description": "Hover over any username on the website to display the profile picture, username and follower count.",
+    "credits": ["Bingus the Bingus", "rgantzos"],
+    "urls": [
+      "https://scratch.mit.edu/users/JefferyTheSuperKat/",
+      "https://scratch.mit.edu/users/rgantzos"
+    ],
+    "file": "unlisted-projects",
+    "type": ["Website"],
+    "tags": ["New", "Recommended"],
+    "dynamic": true
+  },
+  {
     "title": "Search Context Menus",
     "description": "Hover over any username on the website to display the profile picture, username and follower count.",
     "credits": ["Bingus the Bingus", "rgantzos"],

--- a/features/unlisted-projects.js
+++ b/features/unlisted-projects.js
@@ -1,0 +1,105 @@
+async function getToken(projectId) {
+  let projectToken = (
+    await (
+      await fetch(
+        `https://api.scratch.mit.edu/projects/${projectId}?nocache=${Date.now()}`,
+        {
+          headers: {
+            "x-token": ScratchTools.Auth.user.token,
+          },
+        }
+      )
+    ).json()
+  ).project_token;
+  return projectToken;
+}
+
+async function cacheProject() {
+  const projectId = window.location.pathname.split("/")[2];
+  const token = await getToken(projectId);
+  var response = await fetch(
+    `https://unlisted.gantzos.com/cache/${projectId}?token=${token}`
+  );
+  var data = await response.json();
+  return data;
+}
+
+async function uncacheProject() {
+  const projectId = window.location.pathname.split("/")[2];
+  const token = await getToken(projectId);
+  var response = await fetch(
+    `https://unlisted.gantzos.com/uncache/${projectId}?token=${token}`
+  );
+  var data = await response.json();
+  return data;
+}
+
+async function loadCachedProject(projectId) {
+  var response = await fetch(`https://unlisted.gantzos.com/cached/${projectId}/`);
+  var data = await response.json();
+  ScratchTools.Scratch.vm.loadProject(JSON.stringify(data));
+}
+
+async function checkIfCached() {
+  const projectId = window.location.pathname.split("/")[2];
+  const token = await getToken(projectId);
+  var response = await fetch(
+    `https://unlisted.gantzos.com/iscached/${projectId}?token=${token}`
+  );
+  var data = await response.json();
+  return data.isCached;
+}
+
+ScratchTools.waitForElements(
+  "[class*='share-button_share-button']",
+  createButton,
+  "unlisted-projects",
+  false
+);
+
+async function createButton(el) {
+  var el = el || document.querySelector("[class*='share-button_share-button']");
+  el.onclick = createButton;
+  if (el.innerText === "Share") {
+    if (!document.querySelector(".scratchtools-unlisted")) {
+      const classList = document.querySelector(
+        "[class*='share-button_share-button']"
+      ).parentNode.classList;
+      classList.length = 2;
+
+      let btn = document.createElement("div");
+      let span = document.createElement("span");
+      btn.role = "button";
+      btn.className = "button";
+      span.style.backgroundColor = "#ff9f00";
+      btn.classList = classList;
+      span.classList = document.querySelector(
+        "[class*='share-button_share-button']"
+      ).classList;
+      if (await checkIfCached()) {
+        span.textContent = "Make Private";
+        btn.onclick = async function () {
+          await uncacheProject();
+          btn.remove();
+          createButton();
+        };
+      } else {
+        span.textContent = "Make Unlisted";
+        btn.onclick = async function () {
+          const data = await cacheProject();
+          alert(
+            "https://turbowarp.org/editor?project_url=https://unlisted.gantzos.com/cached/" +
+              data.id
+          );
+          btn.remove();
+          createButton();
+        };
+      }
+      btn.classList.add("scratchtools-unlisted");
+      btn.appendChild(span);
+      document
+        .querySelector('[class^="menu-bar_main-menu_"]')
+        .lastChild.before(btn);
+    }
+  }
+}


### PR DESCRIPTION
This feature would allow you to generate a link for your unshared project that can be shared with anyone.

It adds a button to the editor to make a project either unshared or private, depending on the current status.

For storage reasons, only unshared projects can be made unlisted.