### PR TITLE
Move gear icon closer in to make padding even

### DIFF
--- a/extras/popup/popup.css
+++ b/extras/popup/popup.css
@@ -237,7 +237,7 @@ a {
   cursor: pointer;
   float: right;
   margin-top: -6.5em;
-  margin-left: 3em;
+  margin-left: 2.3em;
   position: relative;
   right: -1rem;
 }


### PR DESCRIPTION
Changes a minor css issue
before:
![image](https://user-images.githubusercontent.com/65277548/234740306-25e151d2-373b-4f25-9972-047d71caf216.png)
after:
![image](https://user-images.githubusercontent.com/65277548/234740275-8d1ce557-04f9-4a57-b7a8-5041aeb38107.png)
