### PR TITLE
"Round Profile Pictures" update to feature version 2

### DIFF
--- a/features/features.json
+++ b/features/features.json
@@ -179,17 +179,8 @@
     "type": ["Website"]
   },
   {
-    "title": "Show if Following on Profile",
-    "description": "If a user is following you, it will show next to their username when you visit their profile.",
-    "credits": ["Bob the Potato with Drip", "TimMcCool"],
-    "urls": [
-      "https://scratch.mit.edu/users/JefferyTheSuperKat/",
-      "https://scratch.mit.edu/users/TimMcCool/"
-    ],
-    "file": "follows-you",
-    "type": ["Website"],
-    "tags": ["Featured"],
-    "dynamic": true
+    "version": 2,
+    "id": "follows-you"
   },
   {
     "title": "Custom Studio Section",
@@ -203,15 +194,9 @@
       { "id": "Studio ID", "name": "Studio ID", "default": "27205657" }
     ]
   },
-  {
-    "title": "Highlight Unanswered Forum Topics",
-    "description": "Adds a blue highlight to topics in the forums that have no replies.",
-    "credits": ["rgantzos"],
-    "urls": ["https://scratch.mit.edu/users/rgantzos/"],
-    "file": "highlight-unanswered",
-    "type": ["Website"],
-    "tags": ["New", "Recommended"],
-    "dynamic": true
+    {
+    "version": 2,
+    "id": "highlight-unanswered"
   },
   {
     "title": "Hide Project Tags",
@@ -764,13 +749,8 @@
     "type": ["Website"]
   },
   {
-    "title": "Go to Parent Button",
-    "description": "In the editor for any project that is a remix, you can click a button to go to the editor in the parent project.",
-    "credits": ["rgantzos"],
-    "urls": ["https://scratch.mit.edu/users/rgantzos/"],
-    "file": "go-to-parent",
-    "tags": [],
-    "type": ["Editor"]
+    "version": 2,
+    "id": "go-to-parent"
   },
   {
     "title": "Most Popular Project",
@@ -1013,15 +993,8 @@
     "type": ["Editor"]
   },
   {
-    "title": "Round Profile Pictures",
-    "description": "All profile pictures on the Scratch website will be rounded.",
-    "credits": ["Scratchfangs", "rgantzos"],
-    "urls": [
-      "https://scratch.mit.edu/users/scratchfangs/",
-      "https://scratch.mit.edu/users/rgantzos/"
-    ],
-    "file": "round-profile-pictures",
-    "type": ["Website", "Theme"]
+    "version": 2,
+    "id": "round-profile-pictures"
   },
   {
     "title": "Sidebar",

--- a/features/round-profile-pictures/data.json
+++ b/features/round-profile-pictures/data.json
@@ -1,0 +1,14 @@
+{
+  "title": "Round Profile Pictures",
+  "description": "All profile pictures on the Scratch website will be rounded.",
+  "credits": [
+    { "username": "Scratchfangs", "url": "https://scratch.mit.edu/users/scratchfangs/" },
+    { "username": "rgantzos", "url": "https://scratch.mit.edu/users/rgantzos/" }
+  ],
+  "type": ["Website", "Theme"],
+  "tags": [],
+  "scripts": [{ "file": "script.js", "runOn": "/*" }],
+  "options": [
+    { "id": "Rounding Percentage", "name": "Rounding Percentage", "default": "50%" }
+  ]
+}

--- a/features/round-profile-pictures/script.js
+++ b/features/round-profile-pictures/script.js
@@ -1,0 +1,17 @@
+var roundness = ScratchTools.Storage["Round Percentage"];
+if (!roundness.includes("%")){roundness = roundness.concat("%");}
+function roundProfile() {
+  document.querySelectorAll("img").forEach(function (el) {
+    if (el.src !== undefined) {
+      if (el.src.includes("scratch.mit.edu/get_image/user/")) {
+		el.style.borderRadius = roundness;
+      }
+    }
+	document.querySelectorAll(".mod-social-message").forEach(function (mod) {
+		mod.style.paddingLeft = ".825rem";
+		el.style.paddingRight = "0rem";
+	});
+});
+window.setTimeout(roundProfile, 80);
+}
+roundProfile();


### PR DESCRIPTION
Additional changes:

- Added an option in settings to allow the user to choose the level of rounding percentage.

- Fixed broken rounded edges of profile pictures in the "What's Happening?" box.

Before:

![before](https://github.com/STForScratch/ScratchTools/assets/63302372/8e2f4c11-d820-495c-b22f-59cd2b5bdd42)

After:

![after](https://github.com/STForScratch/ScratchTools/assets/63302372/d6b96375-05b6-4e11-9ddc-5906c138e334)



