### PR TITLE
Fix Colors Not Matching

### DIFF
--- a/features/hide-advertisements/style.css
+++ b/features/hide-advertisements/style.css
@@ -6,7 +6,7 @@ body.colorComment .scratchtoolsAd .comment-bubble, .scratchtoolsAd .comment-bubb
 body.colorComment .scratchtoolsAd .comment-bubble:before {
     border: 1px solid #ff6680;
     border-right: transparent;
-    background-color: #ffd0d0 !important;
+    background-color: #eccedf !important;
 }
 
 body.hideComment .scratchtoolsAd {


### PR DESCRIPTION
Earlier, the colors did not match between the background of the border and the background of the actual comment body itself.