### PR TITLE
Scratch Addons Compatibility Api Function

### DIFF
--- a/api/main.js
+++ b/api/main.js
@@ -125,7 +125,7 @@ ScratchTools.Features.get = function (search) {
   return all[search];
 };
 
-var allSettingChangeFunctions = {}
+var allSettingChangeFunctions = {};
 
 var allDisableFunctions = {};
 ScratchTools.setDisable = function (feature, f) {
@@ -189,4 +189,15 @@ ScratchTools.styles = {
         style.remove();
       });
   },
+};
+
+ScratchTools.saAddonEnabled = function (addon) {
+  if (typeof scratchAddons !== 'undefined') {
+    var i = scratchAddons.eventTargets.self.length;
+    while (i--) {
+      if(scratchAddons.eventTargets.self[i].id === addon) {
+        return true;
+      }
+    }
+  }
 };


### PR DESCRIPTION
I added an API function for use in features that require checking if a conflicting Scratch Addons addon is enabled. If a specified addon is enabled, it will return `true` and `undefined` if not (or if Scratch Addons aren't enabled/installed in the browser at all). Someone creating or fixing a Scratch Tools feature that doesn't work well with another function or functions from Scratch Addons can use this to fix the problem by customizing feature behavior.