### PR TITLE
Fixed more on “revert to blue” feature

### DIFF
--- a/features/original-colors/scratch-www.css
+++ b/features/original-colors/scratch-www.css
@@ -14,7 +14,7 @@ nav#navigation, div[class^="gui_menu-bar-position"] {
 }
 
 button.button, button {
-    background-color: var(--ste-blue);
+    background-color: none;
 }
 
 .news li h4, a:link, a:visited, a:active, a {
@@ -375,11 +375,28 @@ h3 span {
 }
 
 .studio-activity .studio-activity-icon {
-    color: filter: sepia(300%) hue-rotate(185deg) saturate(450%)
+    color: filter sepia(300%) hue-rotate(185deg) saturate(450%)
 }
 
 .title-banner.mod-messages {
     
     background-color: var(--ste-blue);
 
+}
+
+.intro-banner .intro-container {
+    background-color: var(--ste-blue);
+}
+
+.button {
+    background-color: var(--ste-blue);
+}
+.intro-banner .intro-button {
+    color: var(--ste-blue);
+}
+.menu_submenu_2Yzd1 > .menu_menu_3k7QT::-webkit-scrollbar-track {
+    background: hsla(215, 99%, 65%, 1);
+}
+.menu_submenu_2Yzd1 > .menu_menu_3k7QT::-webkit-scrollbar-thumb {
+    border: 3px solid hsla(215, 99%, 65%, 1);
 }

--- a/features/original-colors/scratch-www.css
+++ b/features/original-colors/scratch-www.css
@@ -2,6 +2,7 @@
     --ste-blue: #4e97fe;
     --explore-orange: #ffbf00;
     --explore-green: #338553;
+    --ste-green: #0fbd8c;
     --scratchr2-blue: #278bbfff;
 }
 
@@ -14,7 +15,7 @@ nav#navigation, div[class^="gui_menu-bar-position"] {
 }
 
 button.button, button {
-    background-color: none;
+    background-color: rgba(0,0,0,.1);
 }
 
 .news li h4, a:link, a:visited, a:active, a {
@@ -287,7 +288,7 @@ html, body {
     box-shadow: 0px 0px 0px 4px hsla(210, 100%, 80%, 1);
 }
 .delete-button_delete-button-visible_kym6v {
-    box-shadow: 0px 0px 0px 2px hsla(210, 100%, 80%, 1);
+    box-shadow: 0px 0px 0px 2px hsla(210, 100%, 80%, 0.35);
 }
 .action-menu_more-buttons-outer_3J9yZ {
     background: #4d97ff
@@ -296,13 +297,13 @@ html, body {
     background-color: #4d97ff;
 }
 .action-menu_button_1qbot {
-    background-color: #4d97ff !important;
+    background-color: #4d97ff ;
 }
 .action-menu_main-button_3ccfy {
-    box-shadow: 0 0 0 4px hsla(210, 100%, 80%, 1);
+    box-shadow: 0 0 0 4px hsla(210, 100%, 80%, .75);
 }
 .action-menu_expanded_JcMKp .action-menu_main-button_3ccfy {
-    box-shadow: 0px 0px 0px 2px hsla(210, 100%, 80%, 1);
+    box-shadow: 0px 0px 0px 5px hsla(210, 100%, 80%, .75);
 }
 
 div[class^="menu-bar_menu-bar-menu_"] > ul, div[class^="menu_submenu_"] > ul {
@@ -399,4 +400,20 @@ h3 span {
 }
 .menu_submenu_2Yzd1 > .menu_menu_3k7QT::-webkit-scrollbar-thumb {
     border: 3px solid hsla(215, 99%, 65%, 1);
+}
+
+
+.library-item_library-item_1DcMO:hover {
+    border-color:var(--ste-blue)
+}
+
+.stage-selector_stage-selector_3oWOr:hover {
+    border-color:var(--ste-blue)
+}
+
+.action-menu_main-button_3ccfy:hover {
+    background: hsla(163, 85%, 40%, 1)
+}
+.action-menu_main-button_3ccfy:hover .action-menu_main-icon_1ktMc {
+    background: hsla(163, 85%, 40%, 1)
 }

--- a/features/original-colors/scratch-www.css
+++ b/features/original-colors/scratch-www.css
@@ -68,6 +68,10 @@ button.button, button {
     color: var(--ste-blue);
 }
 
+#comments .comment .info:hover .name a:hover {
+    color: #3397d9;
+}
+
 .feature-banner .feature-learn-more, .feature-banner .feature-banner-image .feature-image-text {
     color: var(--ste-blue);
 }


### PR DESCRIPTION
In the following post on Discord by palindromos: [post](https://discord.com/channels/945340853189247016/1126210918477484052), it was discovered that on some comments, usernames of authors were coloured purple instead of original blue, here is an image from the post (take user mjuio as an example):
![](https://cdn.discordapp.com/attachments/1126210918477484052/1126212586153726062/image.png)

Code fix was given my @MaterArc, but unsure if the blue color specified in hex in the changes should have been `var(—-ste-blue)` instead…?

