### PR TITLE
Adds depreciation warning - Upload Image Feature

### DIFF
--- a/features/features.json
+++ b/features/features.json
@@ -369,6 +369,10 @@
     "file": "upload-img-directly",
     "type": ["Forums"],
     "tags": ["New", "Recommended"]
+    "components": [{
+    "type": "warning",
+    "content": "Due to a recent Scratch update, this feature is no longer supported and does not work anymore."
+  }]
   },
   {
     "title": "Leave Studio Button",


### PR DESCRIPTION
Feature no longer works due to scratch's recent https://assets.scratch.mit.edu/ image-sharing block restriction on the forums