### PR TITLE
Project Version Detector

### DIFF
--- a/features/features.json
+++ b/features/features.json
@@ -1,6 +1,11 @@
 [
   {
     "version": 2,
+    "id": "project-version-detector",
+    "versionAdded": "v3.8.0"
+  },
+  {
+    "version": 2,
     "id": "download-project",
     "versionAdded": "v3.7.0"
   },

--- a/features/project-version-detector/data.json
+++ b/features/project-version-detector/data.json
@@ -1,0 +1,18 @@
+{
+    "title": "Project Version Detector",
+    "description": "Checks when a project was shared and adds a label next to the share date to indicate which version of Scratch was in use at that time.",
+    "credits": [
+      { "username": "MaterArc"
+      , "url": "https://scratch.mit.edu/users/MaterArc/" 
+    }
+    ],
+    "type": ["Website"],
+    "tags": ["New"],
+    "dynamic": true,
+    "styles": [
+      {
+        "file": "script.js",
+        "runOn": "/projects/*"
+      }
+    ]
+  }

--- a/features/project-version-detector/data.json
+++ b/features/project-version-detector/data.json
@@ -1,18 +1,16 @@
 {
-    "title": "Project Version Detector",
-    "description": "Checks when a project was shared and adds a label next to the share date to indicate which version of Scratch was in use at that time.",
-    "credits": [
-      { "username": "MaterArc"
-      , "url": "https://scratch.mit.edu/users/MaterArc/" 
+  "title": "Project Version Detector",
+  "description": "Checks when a project was shared and adds a label next to the share date to indicate which version of Scratch was in use at that time.",
+  "credits": [
+    { "username": "MaterArc", "url": "https://scratch.mit.edu/users/MaterArc/" }
+  ],
+  "type": ["Website"],
+  "tags": ["New"],
+  "dynamic": true,
+  "scripts": [
+    {
+      "file": "script.js",
+      "runOn": "/projects/*"
     }
-    ],
-    "type": ["Website"],
-    "tags": ["New"],
-    "dynamic": true,
-    "styles": [
-      {
-        "file": "script.js",
-        "runOn": "/projects/*"
-      }
-    ]
-  }
+  ]
+}

--- a/features/project-version-detector/script.js
+++ b/features/project-version-detector/script.js
@@ -1,0 +1,36 @@
+const shareDateDiv = document.querySelector('.share-date');
+
+if (shareDateDiv) {
+    const shareDateSpan = shareDateDiv.querySelector('span');
+
+    if (shareDateSpan) {
+        const shareDate = shareDateSpan.textContent.trim();
+        const shareDateObject = new Date(shareDate);
+
+        const versionDates = [
+            { version: "Scratch 1.0", date: new Date("May 15, 2007") },
+            { version: "Scratch 1.1", date: new Date("May 26, 2007") },
+            { version: "Scratch 1.2", date: new Date("December 2, 2007") },
+            { version: "Scratch 1.3", date: new Date("September 2, 2008") },
+            { version: "Scratch 1.3.1", date: new Date("November 24, 2008") },
+            { version: "Scratch 1.4", date: new Date("July 2, 2009") },
+            { version: "Scratch 2.0", date: new Date("May 9, 2013") },
+            { version: "Scratch 3.0", date: new Date("January 2, 2019") },
+        ];
+
+        let detectedVersion = null;
+
+        for (const versionInfo of versionDates) {
+            if (shareDateObject >= versionInfo.date) {
+                detectedVersion = versionInfo.version;
+            } else {
+                break;
+            }
+        }
+
+        const additionalInfoSpan = document.createElement('span');
+        additionalInfoSpan.textContent = ' • Shared in ' + detectedVersion;
+
+        shareDateSpan.parentNode.insertBefore(additionalInfoSpan, shareDateSpan.nextSibling);
+    }
+}

--- a/features/project-version-detector/script.js
+++ b/features/project-version-detector/script.js
@@ -1,7 +1,6 @@
 export default async function ({ feature, console }) {
   ScratchTools.waitForElements("div.share-date", function (shareDateDiv) {
     const shareDateSpan = shareDateDiv.querySelector("span");
-    console.log(shareDateSpan)
 
     if (shareDateSpan) {
       const shareDate = shareDateSpan.textContent.trim();

--- a/features/project-version-detector/script.js
+++ b/features/project-version-detector/script.js
@@ -1,36 +1,42 @@
-const shareDateDiv = document.querySelector('.share-date');
-
-if (shareDateDiv) {
-    const shareDateSpan = shareDateDiv.querySelector('span');
+export default async function ({ feature, console }) {
+  ScratchTools.waitForElements("div.share-date", function (shareDateDiv) {
+    const shareDateSpan = shareDateDiv.querySelector("span");
+    console.log(shareDateSpan)
 
     if (shareDateSpan) {
-        const shareDate = shareDateSpan.textContent.trim();
-        const shareDateObject = new Date(shareDate);
+      const shareDate = shareDateSpan.textContent.trim();
+      const shareDateObject = new Date(shareDate);
 
-        const versionDates = [
-            { version: "Scratch 1.0", date: new Date("May 15, 2007") },
-            { version: "Scratch 1.1", date: new Date("May 26, 2007") },
-            { version: "Scratch 1.2", date: new Date("December 2, 2007") },
-            { version: "Scratch 1.3", date: new Date("September 2, 2008") },
-            { version: "Scratch 1.3.1", date: new Date("November 24, 2008") },
-            { version: "Scratch 1.4", date: new Date("July 2, 2009") },
-            { version: "Scratch 2.0", date: new Date("May 9, 2013") },
-            { version: "Scratch 3.0", date: new Date("January 2, 2019") },
-        ];
+      const versionDates = [
+        { version: "Scratch 1.0", date: new Date("May 15, 2007") },
+        { version: "Scratch 1.1", date: new Date("May 26, 2007") },
+        { version: "Scratch 1.2", date: new Date("December 2, 2007") },
+        { version: "Scratch 1.3", date: new Date("September 2, 2008") },
+        { version: "Scratch 1.3.1", date: new Date("November 24, 2008") },
+        { version: "Scratch 1.4", date: new Date("July 2, 2009") },
+        { version: "Scratch 2.0", date: new Date("May 9, 2013") },
+        { version: "Scratch 3.0", date: new Date("January 2, 2019") },
+      ];
 
-        let detectedVersion = null;
+      let detectedVersion = null;
 
-        for (const versionInfo of versionDates) {
-            if (shareDateObject >= versionInfo.date) {
-                detectedVersion = versionInfo.version;
-            } else {
-                break;
-            }
+      for (const versionInfo of versionDates) {
+        if (shareDateObject >= versionInfo.date) {
+          detectedVersion = versionInfo.version;
+        } else {
+          break;
         }
+      }
 
-        const additionalInfoSpan = document.createElement('span');
-        additionalInfoSpan.textContent = ' • Shared in ' + detectedVersion;
+      const additionalInfoSpan = document.createElement("span");
+      additionalInfoSpan.textContent = " • Shared in " + detectedVersion;
 
-        shareDateSpan.parentNode.insertBefore(additionalInfoSpan, shareDateSpan.nextSibling);
+      shareDateSpan.parentNode.insertBefore(
+        additionalInfoSpan,
+        shareDateSpan.nextSibling
+      );
+
+      feature.self.hideOnDisable(additionalInfoSpan)
     }
+  });
 }


### PR DESCRIPTION
New Feature: Checks when a project was shared and adds a label next to the share date to indicate which version of Scratch was in use at that time.

<img width="1440" alt="Screenshot 2024-03-13 at 10 39 57 PM" src="https://github.com/STForScratch/ScratchTools/assets/105017592/95fd3293-4dc7-49d6-be90-230dd1d1d8d5">
