### PR TITLE
Add feature "fullscreen-explorer"

### DIFF
--- a/features/features.json
+++ b/features/features.json
@@ -1,6 +1,11 @@
 [
   {
     "version": 2,
+    "id": "fullscreen-explorer",
+    "versionAdded": "v3.8.0"
+  },
+  {
+    "version": 2,
     "id": "project-miniplayer",
     "versionAdded": "v3.8.0"
   },

--- a/features/fullscreen-explorer/data.json
+++ b/features/fullscreen-explorer/data.json
@@ -1,6 +1,6 @@
 {
   "title": "Fullscreen Explorer",
-  "description": "Find projects on the big screen by removing the left and right blanks on the Trends, Search, Project Remix, and Studio pages.",
+  "description": "Find projects on the big screen by removing the left and right blanks on the Trends, Search, Remix pages.",
   "credits": [
     { "username": "Masaabu-YT", "url": "https://scratch.mit.edu/users/Masaabu-YT/" }
   ],

--- a/features/fullscreen-explorer/data.json
+++ b/features/fullscreen-explorer/data.json
@@ -1,0 +1,15 @@
+{
+  "title": "Fullscreen Explorer",
+  "description": "Find projects on the big screen by removing the left and right blanks on the Trends, Search, Project Remix, and Studio pages.",
+  "credits": [
+    { "username": "Masaabu-YT", "url": "https://scratch.mit.edu/users/Masaabu-YT/" }
+  ],
+  "type": ["Website"],
+  "tags": ["New", "Featured"],
+  "dynamic": true,
+  "styles": [
+    { "file": "style.css", "runOn": "/explore/*" },
+    { "file": "style.css", "runOn": "/search/*" },
+    { "file": "style2.css", "runOn": "/projects/*" }
+  ]
+}

--- a/features/fullscreen-explorer/data.json
+++ b/features/fullscreen-explorer/data.json
@@ -1,5 +1,5 @@
 {
-  "title": "Fullscreen Explorer",
+  "title": "Fullscreen Project Grids",
   "description": "Find projects on the big screen by removing the left and right blanks on the Trends, Search, Remix pages.",
   "credits": [
     { "username": "Masaabu-YT", "url": "https://scratch.mit.edu/users/Masaabu-YT/" }

--- a/features/fullscreen-explorer/style.css
+++ b/features/fullscreen-explorer/style.css
@@ -1,0 +1,4 @@
+.grid .flex-row {
+    width: 100%;
+    justify-content: center;
+}

--- a/features/fullscreen-explorer/style2.css
+++ b/features/fullscreen-explorer/style2.css
@@ -1,0 +1,12 @@
+.container {
+    display: inline-block;
+    margin: 0;
+}
+
+#content {
+    width: 100%;
+}
+
+#topnav .container {
+    margin: auto;
+}


### PR DESCRIPTION
Find projects on the big screen by removing the left and right blanks on the Trends, Search, Remix pages.
![image](https://github.com/STForScratch/ScratchTools/assets/115585647/c3992d6a-a284-4074-a31f-27e701fc1bef)
![image](https://github.com/STForScratch/ScratchTools/assets/115585647/67fd334e-8d38-4cf5-8a6e-6a1a2b18c0f0)
