### PR TITLE
Update wording for clarity

### DIFF
--- a/features/pin-comments/script.js
+++ b/features/pin-comments/script.js
@@ -74,7 +74,7 @@ export default async function ({ feature, console }) {
 
                 let goToLink = document.createElement("a")
                 goToLink.href = `https://scratch.mit.edu/projects/${pinned.projectId}/#comments-${pinned.commentId}`
-                goToLink.textContent = "view full comment"
+                goToLink.textContent = "view context"
                 goTo.appendChild(goToLink)
 
                 list.parentElement.insertBefore(box, list)


### PR DESCRIPTION
I tested it and the feature works fine in displaying comments that are the full 500 characters (scratch's project comment limit). The original wording, "view full comment" can then be considered confusing to the user, as they might think that the full comment isn't being displayed/is being cut off when it's just the context (replies + original message) that is missing.