### PR TITLE
Fix `Plain-Background`

### DIFF
--- a/features/plain-background/style.css
+++ b/features/plain-background/style.css
@@ -1,3 +1,3 @@
 .blocklyMainBackground {
-  fill: white !important;
+  fill: transparent !important;
 }


### PR DESCRIPTION
Fix plain background feature interfering with the Scratch Addon's `Editor dark mode and customizable colors`

Bug:
<img width="1438" alt="Screenshot 2024-07-01 at 9 19 02 AM" src="https://github.com/MaterArc/ScratchTools/assets/105017592/f3a448d0-1a63-4078-b502-f6b275188084">

Fix: 
<img width="1436" alt="Screenshot 2024-07-01 at 9 23 33 AM" src="https://github.com/MaterArc/ScratchTools/assets/105017592/14a2a5f4-4a2a-48f3-a4db-fbc2d377c956">

_Resolves #756_