### PR TITLE
Fix `Plain-Background`

### DIFF
--- a/features/plain-background/style.css
+++ b/features/plain-background/style.css
@@ -1,3 +1,3 @@
 .blocklyMainBackground {
-  fill: white !important;
+  fill: transparent !important;
 }


### PR DESCRIPTION
Fix plain background feature interfering with the Scratch Addon's `Editor dark mode and customizable colors`

Bug:
<img width="1438" alt="Screenshot 2024-07-01 at 9 19 02 AM" src="https://github.com/STForScratch/ScratchTools/assets/105017592/036abd29-912b-492f-a757-c0d99ab05eb0">


Fix: 
<img width="1440" alt="Screenshot 2024-07-01 at 9 30 11 AM" src="https://github.com/STForScratch/ScratchTools/assets/105017592/a6b18619-188e-46fb-852d-24be5b21d437">


_Resolves #756_