### PR TITLE
Fix feature "project-miniplayer"

### DIFF
--- a/features/project-miniplayer/script.js
+++ b/features/project-miniplayer/script.js
@@ -49,16 +49,23 @@ export default async function ({ feature, console }) {
     updateSetting('position-bottom', await feature.settings.get("position-bottom"));
     updateSetting('opacity', await feature.settings.get("opacity"));
 
-    window.addEventListener('scroll', () => {
-        if (window.scrollY > 700) {
-            miniplayerElement.style.display = 'block';
-            miniplayerElement.appendChild(guiPlayer);
-        } else {
-            miniplayerElement.style.display = 'none';
-            title.insertAdjacentElement('beforebegin', guiPlayer);
-
-        }
-    });
+    const observerOptions = {
+        root: document
+    };
+    const callback = (entries, observer) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                miniplayerElement.style.display = 'none';
+                title.insertAdjacentElement('beforebegin', guiPlayer);
+            } else {
+                miniplayerElement.style.display = 'block';
+                miniplayerElement.appendChild(guiPlayer);
+            }
+        });
+    };
+    const observerObject = new IntersectionObserver(callback, observerOptions);
+    const targetArea = document.querySelector("div.preview .inner .project-notes")
+    observerObject.observe(targetArea);
 
     feature.settings.addEventListener("changed", function({ key, value }) {
         updateSetting(key, value)


### PR DESCRIPTION
Fixed an issue with the mini-player flashing.
We used to display the mini player using window.scrollY, but we have changed it to use the Intersection Observer API.

## Before
https://github.com/STForScratch/ScratchTools/assets/115585647/eaef60f1-510e-4d00-9afc-b1cd81143a4c

## After
https://github.com/STForScratch/ScratchTools/assets/115585647/4f288932-31b3-4e73-a2be-de98abd5b34a
