### PR TITLE
Video recorder feature

### DIFF
--- a/features/features.json
+++ b/features/features.json
@@ -1,6 +1,11 @@
 [
   {
     "version": 2,
+    "id": "video-recorder",
+    "versionAdded": "v4.0.0"
+  },
+  {
+    "version": 2,
     "id": "studio-creation-date",
     "versionAdded": "v4.0.0"
   },

--- a/features/video-recorder/data.json
+++ b/features/video-recorder/data.json
@@ -1,0 +1,26 @@
+{
+  "title": "Video Recorder",
+  "description": "Record videos of Scratch projects.",
+  "credits": [
+    {
+      "username": "stio_studio",
+      "url": "https://stio.studio/"
+    },
+    {
+      "username": "blob2763",
+      "url": "https://blob2763.is-a.dev/"
+    }
+  ],
+  "type": ["Editor"],
+  "tags": ["New", "Featured"],
+  "dynamic": true,
+  "scripts": [
+    {
+      "file": "video-recorder.js",
+      "runOn": "/projects/*"
+    }
+  ],
+  "resources": [
+    { "name": "popup-html", "path": "/popup.html" }
+  ]
+}

--- a/features/video-recorder/data.json
+++ b/features/video-recorder/data.json
@@ -1,6 +1,6 @@
 {
-  "title": "Video Recorder",
-  "description": "Record videos of Scratch projects.",
+  "title": "Record Stage",
+  "description": "Allows you to record the stage for projects while in the editor.",
   "credits": [
     {
       "username": "blob2763",
@@ -13,7 +13,6 @@
   ],
   "type": ["Editor"],
   "tags": ["New", "Featured"],
-  "dynamic": true,
   "scripts": [
     {
       "file": "video-recorder.js",

--- a/features/video-recorder/data.json
+++ b/features/video-recorder/data.json
@@ -20,7 +20,16 @@
       "runOn": "/projects/*"
     }
   ],
+  "styles": [
+    {
+      "file": "style.css",
+      "runOn": "/projects/*"
+    }
+  ],
   "resources": [
-    { "name": "popup-html", "path": "/popup.html" }
+    {
+      "name": "popup-html",
+      "path": "/popup.html"
+    }
   ]
 }

--- a/features/video-recorder/data.json
+++ b/features/video-recorder/data.json
@@ -1,6 +1,6 @@
 {
   "title": "Record Stage",
-  "description": "Allows you to record the stage for projects while in the editor.",
+  "description": "Allows you to record the stage for projects while in the editor or on the project page.",
   "credits": [
     {
       "username": "blob2763",

--- a/features/video-recorder/popup.html
+++ b/features/video-recorder/popup.html
@@ -1,0 +1,53 @@
+<div class="ReactModalPortal">
+    <div class="ReactModal__Overlay ReactModal__Overlay--after-open modal_modal-overlay_1Lcbx">
+        <div class="ReactModal__Content ReactModal__Content--after-open modal_modal-content_1h3ll prompt_modal-content_1BfWj"
+            tabindex="-1" role="dialog" aria-label="Rename Variable">
+            <div class="box_box_2jjDp" dir="ltr" style="flex-direction: column; flex-grow: 1;">
+                <div class="modal_header_1h7ps">
+                    <div class="modal_header-item_2zQTd modal_header-item-title_tLOU5">Video Recording</div>
+                    <div class="modal_header-item_2zQTd modal_header-item-close_2XDeL">
+                        <div aria-label="Close" class="close-button_close-button_lOp2G close-button_large_2oadS"
+                            role="button" tabindex="0"><img class="close-button_close-icon_HBCuO"
+                                src="data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA3LjQ4IDcuNDgiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6MnB4O308L3N0eWxlPjwvZGVmcz48dGl0bGU+aWNvbi0tYWRkPC90aXRsZT48bGluZSBjbGFzcz0iY2xzLTEiIHgxPSIzLjc0IiB5MT0iNi40OCIgeDI9IjMuNzQiIHkyPSIxIi8+PGxpbmUgY2xhc3M9ImNscy0xIiB4MT0iMSIgeTE9IjMuNzQiIHgyPSI2LjQ4IiB5Mj0iMy43NCIvPjwvc3ZnPg==">
+                        </div>
+                    </div>
+                </div>
+                <style>
+                    video {
+                        width: 100%;
+                        height: 100%;
+                        border: 10px solid #ccc;
+                        border-radius: 10px;
+                    }
+                    .STE-hide-button {
+                        display: none;
+                    }
+                    .STE-left-text {
+                        text-align: left;
+                    }
+                    .stopButton, .startButton, .downloadButton, .video-format-select {
+                        width: 100%;
+                    }
+                </style>
+                <div class="prompt_body_18Z-I box_box_2jjDp">
+                    <!-- <div class="prompt_label_tWjYZ box_box_2jjDp"></div>
+                    <div class="box_box_2jjDp"><input class="prompt_variable-name-text-input_1iu8-"
+                            name="Rename all &quot;box size&quot; variables to:" value="box size"></div> -->
+                    <div class="prompt_button-row_3Wc5Z box_box_2jjDp STE-left-text">
+                        <button class="stopButton STE-hide-button"><span>Stop Recording</span></button>
+                        <button class="prompt_ok-button_3QFdD startButton"><span>Start Recording</span></button>
+                        <br><br>
+                        <select class="video-format-select">
+                            <option value="mp4">mp4</option>
+                            <option value="webm">webm</option>
+                        </select>
+                        <br><br>
+                        Video viewed here: <br>
+                        <video></video>
+                        <button class="prompt_ok-button_3QFdD downloadButton"><span>Download Video</span></button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/features/video-recorder/popup.html
+++ b/features/video-recorder/popup.html
@@ -41,7 +41,7 @@
                             name="Rename all &quot;box size&quot; variables to:" value="box size"></div> -->
                     <div class="prompt_button-row_3Wc5Z box_box_2jjDp STE-left-text">
                         <button class="stopButton STE-hide-button"><span>Stop Recording</span></button>
-                        <button class="prompt_ok-button_3QFdD startButton"><span>Start Recording</span></button>
+                        <button class="prompt_ok-button_3QFdD startButton scratchtoolsTag"><span>Start Recording</span></button>
                         <br><br>
                         <select class="video-format-select">
                             <option value="mp4">mp4</option>
@@ -50,7 +50,7 @@
                         <br><br>
                         Preview: <br>
                         <video class="STE-recorded-video"></video>
-                        <button class="prompt_ok-button_3QFdD downloadButton"><span>Download Video</span></button>
+                        <button class="prompt_ok-button_3QFdD downloadButton scratchtoolsTag"><span>Download Video</span></button>
                     </div>
                 </div>
             </div>

--- a/features/video-recorder/popup.html
+++ b/features/video-recorder/popup.html
@@ -1,59 +1,63 @@
 <div class="ReactModalPortal STE-ReactModalPortal">
-    <div class="ReactModal__Overlay ReactModal__Overlay--after-open modal_modal-overlay_1Lcbx">
-        <div class="ReactModal__Content ReactModal__Content--after-open modal_modal-content_1h3ll prompt_modal-content_1BfWj"
-            tabindex="-1" role="dialog" aria-label="Rename Variable">
-            <div class="box_box_2jjDp" dir="ltr" style="flex-direction: column; flex-grow: 1;">
-                <div class="modal_header_1h7ps">
-                    <div class="modal_header-item_2zQTd modal_header-item-title_tLOU5">Video Recording</div>
-                    <div class="modal_header-item_2zQTd modal_header-item-close_2XDeL">
-                        <div aria-label="Close" class="close-button_close-button_lOp2G close-button_large_2oadS"
-                            role="button" tabindex="0"><img class="close-button_close-icon_HBCuO"
-                                src="data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA3LjQ4IDcuNDgiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6MnB4O308L3N0eWxlPjwvZGVmcz48dGl0bGU+aWNvbi0tYWRkPC90aXRsZT48bGluZSBjbGFzcz0iY2xzLTEiIHgxPSIzLjc0IiB5MT0iNi40OCIgeDI9IjMuNzQiIHkyPSIxIi8+PGxpbmUgY2xhc3M9ImNscy0xIiB4MT0iMSIgeTE9IjMuNzQiIHgyPSI2LjQ4IiB5Mj0iMy43NCIvPjwvc3ZnPg==">
-                        </div>
-                    </div>
-                </div>
-                <style>
-                    .STE-ReactModalPortal .STE-recorded-video {
-                        width: 100%;
-                        height: 100%;
-                        border: 10px solid #ccc;
-                        border-radius: 10px;
-                    }
-
-                    .STE-ReactModalPortal .STE-hide-button {
-                        display: none;
-                    }
-
-                    .STE-ReactModalPortal .STE-left-text {
-                        text-align: left;
-                    }
-
-                    .STE-ReactModalPortal .stopButton,
-                    .STE-ReactModalPortal .startButton,
-                    .STE-ReactModalPortal .downloadButton,
-                    .STE-ReactModalPortal .video-format-select {
-                        width: 100%;
-                    }
-                </style>
-                <div class="prompt_body_18Z-I box_box_2jjDp">
-                    <!-- <div class="prompt_label_tWjYZ box_box_2jjDp"></div>
+  <div
+    class="ReactModal__Overlay ReactModal__Overlay--after-open modal_modal-overlay_1Lcbx"
+  >
+    <div
+      class="ReactModal__Content ReactModal__Content--after-open modal_modal-content_1h3ll prompt_modal-content_1BfWj"
+      tabindex="-1"
+      role="dialog"
+      aria-label="Rename Variable"
+    >
+      <div
+        class="box_box_2jjDp"
+        dir="ltr"
+        style="flex-direction: column; flex-grow: 1"
+      >
+        <div class="modal_header_1h7ps">
+          <div class="modal_header-item_2zQTd modal_header-item-title_tLOU5">
+            Video Recording
+          </div>
+          <div class="modal_header-item_2zQTd modal_header-item-close_2XDeL">
+            <div
+              aria-label="Close"
+              class="close-button_close-button_lOp2G close-button_large_2oadS"
+              role="button"
+              tabindex="0"
+            >
+              <img
+                class="close-button_close-icon_HBCuO"
+                src="data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA3LjQ4IDcuNDgiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6MnB4O308L3N0eWxlPjwvZGVmcz48dGl0bGU+aWNvbi0tYWRkPC90aXRsZT48bGluZSBjbGFzcz0iY2xzLTEiIHgxPSIzLjc0IiB5MT0iNi40OCIgeDI9IjMuNzQiIHkyPSIxIi8+PGxpbmUgY2xhc3M9ImNscy0xIiB4MT0iMSIgeTE9IjMuNzQiIHgyPSI2LjQ4IiB5Mj0iMy43NCIvPjwvc3ZnPg=="
+              />
+            </div>
+          </div>
+        </div>
+        <div class="prompt_body_18Z-I box_box_2jjDp">
+          <!-- <div class="prompt_label_tWjYZ box_box_2jjDp"></div>
                     <div class="box_box_2jjDp"><input class="prompt_variable-name-text-input_1iu8-"
                             name="Rename all &quot;box size&quot; variables to:" value="box size"></div> -->
-                    <div class="prompt_button-row_3Wc5Z box_box_2jjDp STE-left-text">
-                        <button class="stopButton STE-hide-button"><span>Stop Recording</span></button>
-                        <button class="prompt_ok-button_3QFdD startButton scratchtoolsTag"><span>Start Recording</span></button>
-                        <br><br>
-                        <select class="video-format-select">
-                            <option value="mp4">mp4</option>
-                            <option value="webm">webm</option>
-                        </select>
-                        <br><br>
-                        Preview: <br>
-                        <video class="STE-recorded-video"></video>
-                        <button class="prompt_ok-button_3QFdD downloadButton scratchtoolsTag"><span>Download Video</span></button>
-                    </div>
-                </div>
-            </div>
+          <div class="prompt_button-row_3Wc5Z box_box_2jjDp STE-left-text">
+            <button class="stopButton STE-hide-button">
+              <span>Stop Recording</span>
+            </button>
+            <button class="prompt_ok-button_3QFdD startButton scratchtoolsTag">
+              <span>Start Recording</span>
+            </button>
+            <br /><br />
+            <select class="video-format-select">
+              <option value="mp4">mp4</option>
+              <option value="webm">webm</option>
+            </select>
+            <br /><br />
+            Preview: <br />
+            <video class="STE-recorded-video"></video>
+            <button
+              class="prompt_ok-button_3QFdD downloadButton scratchtoolsTag"
+            >
+              <span>Download Video</span>
+            </button>
+          </div>
         </div>
+      </div>
     </div>
+  </div>
 </div>

--- a/features/video-recorder/popup.html
+++ b/features/video-recorder/popup.html
@@ -1,4 +1,4 @@
-<div class="ReactModalPortal">
+<div class="ReactModalPortal STE-ReactModalPortal">
     <div class="ReactModal__Overlay ReactModal__Overlay--after-open modal_modal-overlay_1Lcbx">
         <div class="ReactModal__Content ReactModal__Content--after-open modal_modal-content_1h3ll prompt_modal-content_1BfWj"
             tabindex="-1" role="dialog" aria-label="Rename Variable">

--- a/features/video-recorder/popup.html
+++ b/features/video-recorder/popup.html
@@ -13,19 +13,25 @@
                     </div>
                 </div>
                 <style>
-                    video {
+                    .STE-ReactModalPortal .STE-recorded-video {
                         width: 100%;
                         height: 100%;
                         border: 10px solid #ccc;
                         border-radius: 10px;
                     }
-                    .STE-hide-button {
+
+                    .STE-ReactModalPortal .STE-hide-button {
                         display: none;
                     }
-                    .STE-left-text {
+
+                    .STE-ReactModalPortal .STE-left-text {
                         text-align: left;
                     }
-                    .stopButton, .startButton, .downloadButton, .video-format-select {
+
+                    .STE-ReactModalPortal .stopButton,
+                    .STE-ReactModalPortal .startButton,
+                    .STE-ReactModalPortal .downloadButton,
+                    .STE-ReactModalPortal .video-format-select {
                         width: 100%;
                     }
                 </style>
@@ -43,7 +49,7 @@
                         </select>
                         <br><br>
                         Preview: <br>
-                        <video></video>
+                        <video class="STE-recorded-video"></video>
                         <button class="prompt_ok-button_3QFdD downloadButton"><span>Download Video</span></button>
                     </div>
                 </div>

--- a/features/video-recorder/popup.html
+++ b/features/video-recorder/popup.html
@@ -1,33 +1,18 @@
 <div class="ReactModalPortal STE-ReactModalPortal">
-  <div
-    class="ReactModal__Overlay ReactModal__Overlay--after-open modal_modal-overlay_1Lcbx"
-  >
+  <div class="ReactModal__Overlay ReactModal__Overlay--after-open modal_modal-overlay_1Lcbx">
     <div
       class="ReactModal__Content ReactModal__Content--after-open modal_modal-content_1h3ll prompt_modal-content_1BfWj"
-      tabindex="-1"
-      role="dialog"
-      aria-label="Rename Variable"
-    >
-      <div
-        class="box_box_2jjDp"
-        dir="ltr"
-        style="flex-direction: column; flex-grow: 1"
-      >
+      tabindex="-1" role="dialog" aria-label="Rename Variable">
+      <div class="box_box_2jjDp" dir="ltr" style="flex-direction: column; flex-grow: 1">
         <div class="modal_header_1h7ps">
           <div class="modal_header-item_2zQTd modal_header-item-title_tLOU5">
             Video Recording
           </div>
           <div class="modal_header-item_2zQTd modal_header-item-close_2XDeL">
-            <div
-              aria-label="Close"
-              class="close-button_close-button_lOp2G close-button_large_2oadS"
-              role="button"
-              tabindex="0"
-            >
-              <img
-                class="close-button_close-icon_HBCuO"
-                src="data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA3LjQ4IDcuNDgiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6MnB4O308L3N0eWxlPjwvZGVmcz48dGl0bGU+aWNvbi0tYWRkPC90aXRsZT48bGluZSBjbGFzcz0iY2xzLTEiIHgxPSIzLjc0IiB5MT0iNi40OCIgeDI9IjMuNzQiIHkyPSIxIi8+PGxpbmUgY2xhc3M9ImNscy0xIiB4MT0iMSIgeTE9IjMuNzQiIHgyPSI2LjQ4IiB5Mj0iMy43NCIvPjwvc3ZnPg=="
-              />
+            <div aria-label="Close" class="close-button_close-button_lOp2G close-button_large_2oadS" role="button"
+              tabindex="0">
+              <img class="close-button_close-icon_HBCuO"
+                src="data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA3LjQ4IDcuNDgiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6MnB4O308L3N0eWxlPjwvZGVmcz48dGl0bGU+aWNvbi0tYWRkPC90aXRsZT48bGluZSBjbGFzcz0iY2xzLTEiIHgxPSIzLjc0IiB5MT0iNi40OCIgeDI9IjMuNzQiIHkyPSIxIi8+PGxpbmUgY2xhc3M9ImNscy0xIiB4MT0iMSIgeTE9IjMuNzQiIHgyPSI2LjQ4IiB5Mj0iMy43NCIvPjwvc3ZnPg==" />
             </div>
           </div>
         </div>
@@ -43,6 +28,10 @@
               <span>Start Recording</span>
             </button>
             <br /><br />
+            Microphone: <input type="checkbox" class="microphoneCheckbox">
+            <br />
+            Desktop sound: <input type="checkbox" class="desktopSoundCheckbox" checked>
+            <br />
             <select class="video-format-select">
               <option value="mp4">mp4</option>
               <option value="webm">webm</option>
@@ -50,9 +39,7 @@
             <br /><br />
             Preview: <br />
             <video class="STE-recorded-video"></video>
-            <button
-              class="prompt_ok-button_3QFdD downloadButton scratchtoolsTag"
-            >
+            <button class="prompt_ok-button_3QFdD downloadButton scratchtoolsTag">
               <span>Download Video</span>
             </button>
           </div>

--- a/features/video-recorder/style.css
+++ b/features/video-recorder/style.css
@@ -1,0 +1,21 @@
+.STE-ReactModalPortal .STE-recorded-video {
+  width: 100%;
+  height: 100%;
+  border: 10px solid #ccc;
+  border-radius: 10px;
+}
+
+.STE-ReactModalPortal .STE-hide-button {
+  display: none;
+}
+
+.STE-ReactModalPortal .STE-left-text {
+  text-align: left;
+}
+
+.STE-ReactModalPortal .stopButton,
+.STE-ReactModalPortal .startButton,
+.STE-ReactModalPortal .downloadButton,
+.STE-ReactModalPortal .video-format-select {
+  width: 100%;
+}

--- a/features/video-recorder/style.css
+++ b/features/video-recorder/style.css
@@ -19,3 +19,4 @@
 .STE-ReactModalPortal .video-format-select {
   width: 100%;
 }
+

--- a/features/video-recorder/video-recorder.js
+++ b/features/video-recorder/video-recorder.js
@@ -11,7 +11,7 @@ export default async function ({ feature, console }) {
 	})
 
 	let openPopup = document.createElement("button");
-	
+
 	ScratchTools.waitForElements(".preview .inner .flex-row.action-buttons", async function (row) {
 		if (row.querySelector(".ste-video-recorder-open")) return;
 		openPopup = document.createElement("button");
@@ -20,8 +20,9 @@ export default async function ({ feature, console }) {
 		row.insertAdjacentElement("afterbegin", openPopup);
 		openPopup.addEventListener('click', () => {
 			document.body.append(popup)
-		})	
+		})
 	})
+
 	ScratchTools.waitForElements(".menu-bar_account-info-group_MeJZP", async function (row) {
 		if (row.querySelector(".ste-video-recorder-open")) return;
 		openPopup = document.createElement("div");
@@ -32,7 +33,7 @@ export default async function ({ feature, console }) {
 		row.insertAdjacentElement("afterbegin", openPopup);
 		openPopup.addEventListener('click', () => {
 			document.body.append(popup)
-		})	
+		})
 	})
 
 	let popup = document.createElement("div");
@@ -45,7 +46,8 @@ export default async function ({ feature, console }) {
 	let downloadButton = popup.querySelector(".downloadButton");
 	let lastDownloadFunction = () => { }
 	let mimeType = popup.querySelector("select");
-
+	let microphoneCheckbox = popup.querySelector(".microphoneCheckbox");
+	let desktopSoundCheckbox = popup.querySelector(".desktopSoundCheckbox");
 
 	closeButton.addEventListener('click', () => {
 		document.querySelector(".STE-ReactModalPortal").remove()
@@ -58,20 +60,79 @@ export default async function ({ feature, console }) {
 
 	const canvas = feature.traps.vm.renderer.canvas;
 	const preview = popup.querySelector("video")
-	const projectTitle = document.querySelector("input.inplace-input") || document.querySelector("input.project-title-input_title-field_en5Gd")
-	// document.querySelector(".menu-bar_account-info-group_MeJZP").append(preview)
+
+	await new Promise(async (resolve, reject) => {
+		(async () => {
+			const rem = await ScratchTools.waitForElement("input.inplace-input")
+			resolve(rem);
+		})();
+		(async () => {
+			const rem = await ScratchTools.waitForElement("input.project-title-input_title-field_en5Gd")
+			resolve(rem);
+		})();
+		(async () => {
+			const rem = await ScratchTools.waitForElement(".project-title")
+			resolve(rem);
+		})();
+	})
+
+	let projectTitle = document.querySelector("input.inplace-input") || document.querySelector("input.project-title-input_title-field_en5Gd") || document.querySelector(".project-title");
+
+	ScratchTools.waitForElements("input.inplace-input", async function (_projectTitle) {
+		projectTitle = _projectTitle
+	})
+
+	ScratchTools.waitForElements("input.project-title-input_title-field_en5Gd", async function (_projectTitle) {
+		projectTitle = _projectTitle
+	})
+
+	ScratchTools.waitForElements(".project-title", async function (_projectTitle) {
+		projectTitle = _projectTitle
+	})
+
 
 	let mediaRecorder;
 	let recordedChunks = [];
-	// console.log(startButton)
-	// Start recording
-	startButton.addEventListener('click', () => {
+
+	startButton.addEventListener('click', async () => {
 		startButton.classList.add("STE-hide-button");
 		stopButton.classList.remove("STE-hide-button");
 
 		// Capture the canvas element as a stream
-		const stream = canvas.captureStream(30); // 30 FPS
-		mediaRecorder = new MediaRecorder(stream);
+		const canvasStream = canvas.captureStream(30); // 30 FPS
+
+		// Get the audio context from the Scratch VM
+		const audioContext = feature.traps.vm.runtime.audioEngine.audioContext;
+		const audioDestination = audioContext.createMediaStreamDestination();
+
+		if (microphoneCheckbox.checked) {
+			// Capture the microphone audio
+			let micStream;
+			try {
+				micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+			} catch (err) {
+				console.error("Error capturing microphone audio:", err);
+			}
+
+			if (micStream) {
+				const micSource = audioContext.createMediaStreamSource(micStream);
+				micSource.connect(audioDestination);
+			}
+		}
+
+		// Connect the audio engine's output
+		if (desktopSoundCheckbox.checked) {
+			feature.traps.vm.runtime.audioEngine.inputNode.connect(audioDestination);
+		}
+
+		// Combine the canvas video track and audio tracks
+		const combinedStream = new MediaStream();
+		canvasStream.getVideoTracks().forEach(track => combinedStream.addTrack(track));
+		if (microphoneCheckbox.checked || desktopSoundCheckbox.checked) {
+			audioDestination.stream.getAudioTracks().forEach(track => combinedStream.addTrack(track));
+		}
+
+		mediaRecorder = new MediaRecorder(combinedStream);
 
 		mediaRecorder.ondataavailable = function (event) {
 			if (event.data.size > 0) {
@@ -85,19 +146,20 @@ export default async function ({ feature, console }) {
 			});
 			preview.src = URL.createObjectURL(blob);
 			preview.controls = true;
-			preview.download = `${projectTitle.value}.${mimeType.value}`
-			downloadButton.removeEventListener("click", lastDownloadFunction)
+			// console.log(projectTitle)
+			preview.download = `${projectTitle.value}.${mimeType.value}`;
+			downloadButton.removeEventListener("click", lastDownloadFunction);
 			lastDownloadFunction = async () => {
-				const url = URL.createObjectURL(blob)
-				const a = document.createElement('a')
-				a.href = url
-				a.download = `${projectTitle.value}.${mimeType.value}`
-				document.body.appendChild(a)
-				a.click()
-				document.body.removeChild(a)
-				URL.revokeObjectURL(url)
+				const url = URL.createObjectURL(blob);
+				const a = document.createElement('a');
+				a.href = url;
+				a.download = `${projectTitle.value}.${mimeType.value}`;
+				document.body.appendChild(a);
+				a.click();
+				document.body.removeChild(a);
+				URL.revokeObjectURL(url);
 			}
-			downloadButton.addEventListener("click", lastDownloadFunction)
+			downloadButton.addEventListener("click", lastDownloadFunction);
 			recordedChunks = [];
 		};
 
@@ -106,7 +168,6 @@ export default async function ({ feature, console }) {
 		stopButton.disabled = false;
 	});
 
-	// Stop recording
 	stopButton.addEventListener('click', () => {
 		mediaRecorder.stop();
 		startButton.disabled = false;

--- a/features/video-recorder/video-recorder.js
+++ b/features/video-recorder/video-recorder.js
@@ -1,11 +1,7 @@
 export default async function ({ feature, console }) {
-	let openPopup = document.createElement("button");
-	openPopup.className = "button action-button ste-video-recorder-open";
-	openPopup.textContent = "Record Video";
-
 	await new Promise(async (resolve, reject) => {
 		(async () => {
-			const rem = await ScratchTools.waitForElement(".preview .inner .flex-row.action-buttons")			
+			const rem = await ScratchTools.waitForElement(".preview .inner .flex-row.action-buttons")
 			resolve(rem);
 		})();
 		(async () => {
@@ -13,16 +9,30 @@ export default async function ({ feature, console }) {
 			resolve(rem);
 		})();
 	})
+
+	let openPopup = document.createElement("button");
 	
 	ScratchTools.waitForElements(".preview .inner .flex-row.action-buttons", async function (row) {
 		if (row.querySelector(".ste-video-recorder-open")) return;
+		openPopup = document.createElement("button");
+		openPopup.className = "button action-button ste-video-recorder-open";
+		openPopup.textContent = "Record Video";
 		row.insertAdjacentElement("afterbegin", openPopup);
+		openPopup.addEventListener('click', () => {
+			document.body.append(popup)
+		})	
 	})
 	ScratchTools.waitForElements(".menu-bar_account-info-group_MeJZP", async function (row) {
 		if (row.querySelector(".ste-video-recorder-open")) return;
+		openPopup = document.createElement("div");
+		openPopup.className = "menu-bar_menu-bar-item_oLDa- menu-bar_hoverable_c6WFB";
+		openPopup.textContent = "Record Video";
 		row.insertAdjacentElement("afterbegin", openPopup);
+		openPopup.addEventListener('click', () => {
+			document.body.append(popup)
+		})	
 	})
-	
+
 	let popup = document.createElement("div");
 	popup.insertAdjacentHTML("afterbegin", await (await fetch(feature.self.getResource("popup-html"))).text())
 	popup = popup.querySelector("div.ReactModalPortal")
@@ -31,17 +41,10 @@ export default async function ({ feature, console }) {
 	let startButton = popup.querySelector(".startButton");
 	let closeButton = popup.querySelector(".close-button_close-button_lOp2G");
 	let downloadButton = popup.querySelector(".downloadButton");
-	let lastDownloadFunction = ()=>{}
+	let lastDownloadFunction = () => { }
 	let mimeType = popup.querySelector("select");
 
 
-	// console.log([stopButton, startButton])
-
-	openPopup.addEventListener('click', () => {
-		document.body.append(popup)
-	})
-
-	// console.log(closeButton)
 	closeButton.addEventListener('click', () => {
 		document.querySelector(".STE-ReactModalPortal").remove()
 	})
@@ -82,7 +85,7 @@ export default async function ({ feature, console }) {
 			preview.controls = true;
 			preview.download = `${projectTitle.value}.${mimeType.value}`
 			downloadButton.removeEventListener("click", lastDownloadFunction)
-			lastDownloadFunction =  async () => {
+			lastDownloadFunction = async () => {
 				const url = URL.createObjectURL(blob)
 				const a = document.createElement('a')
 				a.href = url

--- a/features/video-recorder/video-recorder.js
+++ b/features/video-recorder/video-recorder.js
@@ -26,7 +26,9 @@ export default async function ({ feature, console }) {
 		if (row.querySelector(".ste-video-recorder-open")) return;
 		openPopup = document.createElement("div");
 		openPopup.className = "menu-bar_menu-bar-item_oLDa- menu-bar_hoverable_c6WFB";
-		openPopup.textContent = "Record Video";
+		let rem = document.createElement("div");
+		rem.textContent = "Record Video";
+		openPopup.append(rem);
 		row.insertAdjacentElement("afterbegin", openPopup);
 		openPopup.addEventListener('click', () => {
 			document.body.append(popup)

--- a/features/video-recorder/video-recorder.js
+++ b/features/video-recorder/video-recorder.js
@@ -27,6 +27,7 @@ export default async function ({ feature, console }) {
 		if (row.querySelector(".ste-video-recorder-open")) return;
 		openPopup = document.createElement("div");
 		openPopup.className = "menu-bar_menu-bar-item_oLDa- menu-bar_hoverable_c6WFB";
+		openPopup.style.padding = "0 0.75rem"
 		let rem = document.createElement("div");
 		rem.textContent = "Record Video";
 		openPopup.append(rem);

--- a/features/video-recorder/video-recorder.js
+++ b/features/video-recorder/video-recorder.js
@@ -1,0 +1,109 @@
+export default async function ({ feature, console }) {
+
+	const row = await new Promise(async (resolve, reject) => {
+		(async () => {
+			const rem = await ScratchTools.waitForElement(".preview .inner .flex-row.action-buttons")
+			resolve(rem);
+		})();
+		(async () => {
+			const rem = await ScratchTools.waitForElement(".menu-bar_account-info-group_MeJZP")
+			resolve(rem);
+		})();
+	})
+
+	let openPopup = document.createElement("button");
+	openPopup.className = "button action-button ste-video-recorder-open";
+	openPopup.textContent = "Record Video";
+	row.insertAdjacentElement("afterbegin", openPopup);
+
+	let popup = document.createElement("div");
+	popup.insertAdjacentHTML("afterbegin", await (await fetch(feature.self.getResource("popup-html"))).text())
+	popup = popup.querySelector("div.ReactModalPortal")
+
+	let stopButton = popup.querySelector(".stopButton");
+	let startButton = popup.querySelector(".startButton");
+	let closeButton = popup.querySelector(".close-button_close-button_lOp2G");
+	let downloadButton = popup.querySelector(".downloadButton");
+	let lastDownloadFunction = ()=>{}
+	let mimeType = popup.querySelector("select");
+
+
+	// console.log([stopButton, startButton])
+
+	openPopup.addEventListener('click', () => {
+		document.body.append(popup)
+	})
+
+	// console.log(closeButton)
+	closeButton.addEventListener('click', () => {
+		document.querySelector(".ReactModalPortal").remove()
+	})
+	popup.querySelector(".ReactModal__Overlay").addEventListener('click', () => {
+		document.querySelector(".ReactModalPortal").remove()
+	})
+	addEventListener("keydown", (e) => {
+		if (e.key === "Escape") {
+			document.querySelector(".ReactModalPortal").remove()
+		}
+	})
+
+	const canvas = feature.traps.vm.renderer.canvas;
+	const preview = popup.querySelector("video")
+	const projectTitle = document.querySelector("input.inplace-input") || document.querySelector("input.project-title-input_title-field_en5Gd")
+	// document.querySelector(".menu-bar_account-info-group_MeJZP").append(preview)
+
+	let mediaRecorder;
+	let recordedChunks = [];
+	// console.log(startButton)
+	// Start recording
+	startButton.addEventListener('click', () => {
+		startButton.classList.add("STE-hide-button");
+		stopButton.classList.remove("STE-hide-button");
+
+		// Capture the canvas element as a stream
+		const stream = canvas.captureStream(30); // 30 FPS
+		mediaRecorder = new MediaRecorder(stream);
+
+		mediaRecorder.ondataavailable = function (event) {
+			if (event.data.size > 0) {
+				recordedChunks.push(event.data);
+			}
+		};
+
+		mediaRecorder.onstop = function () {
+			const blob = new Blob(recordedChunks, {
+				type: `video/${mimeType.value}`
+			});
+			preview.src = URL.createObjectURL(blob);
+			preview.controls = true;
+			preview.download = `${projectTitle.value}.${mimeType.value}`
+			downloadButton.removeEventListener("click", lastDownloadFunction)
+			lastDownloadFunction =  async () => {
+				const url = URL.createObjectURL(blob)
+				const a = document.createElement('a')
+				a.href = url
+				a.download = `${projectTitle.value}.${mimeType.value}`
+				document.body.appendChild(a)
+				a.click()
+				document.body.removeChild(a)
+				URL.revokeObjectURL(url)
+			}
+			downloadButton.addEventListener("click", lastDownloadFunction)
+			recordedChunks = [];
+		};
+
+		mediaRecorder.start();
+		startButton.disabled = true;
+		stopButton.disabled = false;
+	});
+
+	// Stop recording
+	stopButton.addEventListener('click', () => {
+		mediaRecorder.stop();
+		startButton.disabled = false;
+		stopButton.disabled = true;
+
+		stopButton.classList.add("STE-hide-button");
+		startButton.classList.remove("STE-hide-button");
+	});
+}

--- a/features/video-recorder/video-recorder.js
+++ b/features/video-recorder/video-recorder.js
@@ -36,14 +36,11 @@ export default async function ({ feature, console }) {
 
 	// console.log(closeButton)
 	closeButton.addEventListener('click', () => {
-		document.querySelector(".ReactModalPortal").remove()
-	})
-	popup.querySelector(".ReactModal__Overlay").addEventListener('click', () => {
-		document.querySelector(".ReactModalPortal").remove()
+		document.querySelector(".STE-ReactModalPortal").remove()
 	})
 	addEventListener("keydown", (e) => {
 		if (e.key === "Escape") {
-			document.querySelector(".ReactModalPortal").remove()
+			document.querySelector(".STE-ReactModalPortal").remove()
 		}
 	})
 

--- a/features/video-recorder/video-recorder.js
+++ b/features/video-recorder/video-recorder.js
@@ -1,8 +1,11 @@
 export default async function ({ feature, console }) {
+	let openPopup = document.createElement("button");
+	openPopup.className = "button action-button ste-video-recorder-open";
+	openPopup.textContent = "Record Video";
 
-	const row = await new Promise(async (resolve, reject) => {
+	await new Promise(async (resolve, reject) => {
 		(async () => {
-			const rem = await ScratchTools.waitForElement(".preview .inner .flex-row.action-buttons")
+			const rem = await ScratchTools.waitForElement(".preview .inner .flex-row.action-buttons")			
 			resolve(rem);
 		})();
 		(async () => {
@@ -10,12 +13,16 @@ export default async function ({ feature, console }) {
 			resolve(rem);
 		})();
 	})
-
-	let openPopup = document.createElement("button");
-	openPopup.className = "button action-button ste-video-recorder-open";
-	openPopup.textContent = "Record Video";
-	row.insertAdjacentElement("afterbegin", openPopup);
-
+	
+	ScratchTools.waitForElements(".preview .inner .flex-row.action-buttons", async function (row) {
+		if (row.querySelector(".ste-video-recorder-open")) return;
+		row.insertAdjacentElement("afterbegin", openPopup);
+	})
+	ScratchTools.waitForElements(".menu-bar_account-info-group_MeJZP", async function (row) {
+		if (row.querySelector(".ste-video-recorder-open")) return;
+		row.insertAdjacentElement("afterbegin", openPopup);
+	})
+	
 	let popup = document.createElement("div");
 	popup.insertAdjacentHTML("afterbegin", await (await fetch(feature.self.getResource("popup-html"))).text())
 	popup = popup.querySelector("div.ReactModalPortal")


### PR DESCRIPTION
Record videos of Scratch projects. The user can choose between webm and mp4.

Bug that should be fixed:
When switching between project and editor view, the record video button does not come back. 

Buttons:
![image](https://github.com/user-attachments/assets/ea54e49b-20cd-4519-99b2-56daf444af0d)
![image](https://github.com/user-attachments/assets/a7955ed9-0f8e-425c-9948-6a7cf2bc82ab)


Popup:
![image](https://github.com/user-attachments/assets/42f07329-723e-4675-ab61-ba5df3e58392)