### PR TITLE
Fix API`feature.traps.paint()` can't get

### DIFF
--- a/api/vm.js
+++ b/api/vm.js
@@ -176,7 +176,7 @@ ScratchTools.Scratch.waitForContextMenu = function (info) {
 };
 
 ScratchTools.Scratch.scratchPaint = function () {
-  var app = document.querySelector(".paint-editor_mode-selector_28iiQ");
+  var app = document.querySelector(".paint-editor_mode-selector_28iiQ")||document.querySelector(".paint-editor_mode-selector_O2uhP");
   if (app !== null) {
     return (
       app[

--- a/api/vm.js
+++ b/api/vm.js
@@ -176,7 +176,7 @@ ScratchTools.Scratch.waitForContextMenu = function (info) {
 };
 
 ScratchTools.Scratch.scratchPaint = function () {
-  var app = document.querySelector(".paint-editor_mode-selector_28iiQ")||document.querySelector(".paint-editor_mode-selector_O2uhP");
+  var app = document.querySelector(".paint-editor_mode-selector_28iiQ")||document.querySelector(".paint-editor_mode-selector_O2uhP")||document.querySelector("[class*='paint-editor_mode-selector_']");
   if (app !== null) {
     return (
       app[


### PR DESCRIPTION
In my environment, the paint editor feature wasn't working, and upon investigating the cause, I noticed that feature.traps.paint() was returning null. Further investigation revealed that the class name for the paint editor's mode selector had changed from `paint-editor_mode-selector_28iiQ` to `paint-editor_mode-selector_O2uhP`. As a result, I updated the code to search for the new class name when the element with the old class name `paint-editor_mode-selector_28iiQ` couldn't be found. At least in my environment, this issue has been resolved.