### PR TITLE
Remove Delete Confirmation

### DIFF
--- a/features/features.json
+++ b/features/features.json
@@ -1,6 +1,11 @@
 [
   {
     "version": 2,
+    "id": "remove-confirmation",
+    "versionAdded": "v4.0.0"
+  },
+  {
+    "version": 2,
     "id": "outline-shape-options",
     "versionAdded": "v4.0.0"
   },

--- a/features/remove-confirmation/data.json
+++ b/features/remove-confirmation/data.json
@@ -1,0 +1,13 @@
+{
+    "title": "Remove Delete Confirmation",
+    "description": "Removes the delete confirmation prompt when deleting sprites in the Scratch editor.",
+    "credits": [
+      { "username": "MaterArc", "url": "https://scratch.mit.edu/users/MaterArc/" }
+    ],
+    "type": ["Editor"],
+    "tags": ["New", "Featured"],
+    "dynamic": true,
+    "styles": [{ "file": "style.css", "runOn": "/editor/*" }],
+    "scripts": [{ "file": "script.js", "runOn": "/editor/*" }]
+  }
+  

--- a/features/remove-confirmation/script.js
+++ b/features/remove-confirmation/script.js
@@ -1,0 +1,12 @@
+export default async function ({ feature, console }) {
+  ScratchTools.waitForElements("body", () => {
+    document.body.addEventListener("click", () => {
+      ScratchTools.waitForElements(
+        "[class^='delete-confirmation-prompt_ok-button_']",
+        (confirmButton) => {
+          if (feature.self.enabled) confirmButton.click();
+        }
+      );
+    });
+  });
+}

--- a/features/remove-confirmation/style.css
+++ b/features/remove-confirmation/style.css
@@ -1,0 +1,4 @@
+[class*="delete-confirmation-prompt_modal-container"] {
+    visibility: hidden;
+  }
+  


### PR DESCRIPTION
Removes the delete confirmation prompt when deleting sprites in the Scratch editor.
<img width="475" alt="Screenshot 2024-12-28 at 11 33 11 AM" src="https://github.com/user-attachments/assets/8bee75f8-3f4d-420e-8932-014522d98a24" />


