### PR TITLE
Fix Turbowarp Editor Button

### DIFF
--- a/features/turbowarp-button-in-editor.js
+++ b/features/turbowarp-button-in-editor.js
@@ -4,7 +4,7 @@ if (
 ) {
   function checkForNavForTurbowarp() {
     if (document.querySelector("div.scratchtoolsTurbowarp") === null) {
-      if (document.querySelector(".menu-bar_main-menu_3wjWH") !== null) {
+      if (document.querySelector("[class^='menu-bar_main-menu_']") !== null) {
         waitForNavForTurbowarp.disconnect();
         var outerDiv = document.createElement("div");
         outerDiv.className =
@@ -54,7 +54,7 @@ if (
         a.appendChild(outerSpan);
         outerDiv.appendChild(a);
         document
-          .querySelector(".menu-bar_main-menu_3wjWH")
+          .querySelector("[class^='menu-bar_main-menu_']")
           .appendChild(outerDiv);
       }
     }


### PR DESCRIPTION
Before, the button wouldn't appear because of the use of hashed classes. Now the feature uses an attribute selector.

<img width="1437" alt="Screenshot 2025-02-02 at 11 22 59 AM" src="https://github.com/user-attachments/assets/867d8dec-9bdb-4c09-a612-d1fb1c91c0e5" />
