### PR TITLE
Move "View All" from being inside the scrollbar

### DIFF
--- a/api/update/style.css
+++ b/api/update/style.css
@@ -129,10 +129,10 @@
     position: absolute;
     left: 50%;
     top: calc(50% + calc(3 * 16px));
-    transform: translateX(-50%) translateY(-50%);
+    transform: translateX(-50%) translateY(-150%);
     font-size: calc(1 * 16px);
     font-weight: 600;
     color: black;
-    opacity: .6;
+    opacity: .65;
     cursor: pointer;
 }


### PR DESCRIPTION
Resolves #997 

Moves the "View All" button up so it doesn't get covered by the scrollbar anymore, and makes it slightly more opaque (for slightly better visibility)

![image](https://github.com/user-attachments/assets/bf0f0782-9f76-4902-bccc-b42c6e968dda)
![image](https://github.com/user-attachments/assets/c7ebab52-1554-4e0d-a20a-c176625b7379)
