### PR TITLE
Revamp Total Stats

### DIFF
--- a/features/features.json
+++ b/features/features.json
@@ -1,6 +1,11 @@
 [
   {
     "version": 2,
+    "id": "total-stats",
+    "versionAdded": "v4.2.0"
+  },
+  {
+    "version": 2,
     "id": "copy-paste-lists",
     "versionAdded": "v4.2.0"
   },
@@ -157,11 +162,6 @@
   {
     "version": 2,
     "id": "project-descriptions",
-    "versionAdded": "v3.8.0"
-  },
-  {
-    "version": 2,
-    "id": "total-stats",
     "versionAdded": "v3.8.0"
   },
   {

--- a/features/total-stats/data.json
+++ b/features/total-stats/data.json
@@ -1,33 +1,23 @@
 {
-    "title": "Total User Stats",
-    "description": "Next to shared projects on a user's profile, displays the total loves, favorites and views that the user has received across all of their shared projects.",
-    "credits": [
-        {
-            "username": "RowanMoonBoy",
-            "url": "https://scratch.mit.edu/users/RowanMoonBoy/"
-        },
-        {
-            "username": "rgantzos",
-            "url": "https://scratch.mit.edu/users/rgantzos/"
-        }
-    ],
-    "dynamic": true,
-    "styles": [
-        {
-            "file": "style.css",
-            "runOn": "/users/*"
-        }
-    ],
-    "scripts": [
-        {
-            "file": "script.js",
-            "runOn": "/users/*"
-        }
-    ],
-    "tags": [
-        "New"
-    ],
-    "type": [
-        "Website"
-    ]
+  "title": "Total Project Stats",
+  "description": "Displays a box on user profiles showing the total loves, favorites, views, and remixes across all their shared projects.",
+  "credits": [
+    {
+      "username": "RowanMoonBoy",
+      "url": "https://scratch.mit.edu/users/RowanMoonBoy/"
+    },
+    {
+      "username": "MaterArc",
+      "url": "https://scratch.mit.edu/users/MaterArc/"
+    }
+  ],
+  "type": ["Website"],
+  "tags": ["New", "Featured"],
+  "dynamic": true,
+  "scripts": [
+    {
+      "file": "script.js",
+      "runOn": "/users/*"
+    }
+  ]
 }

--- a/features/total-stats/style.css
+++ b/features/total-stats/style.css
@@ -1,7 +1,0 @@
-.ste-total-stats {
-    font-weight: 500;
-    opacity: .6;
-    margin-left: 1rem;
-    font-style: italic;
-    font-size: .9rem;
-}


### PR DESCRIPTION
Revamp the total stats feature to look nicer and have it's own row like originally suggested in palindromos's mockup (and fix the total remixes not showing up)

Here's how it looks now:
<img width="1440" alt="Screenshot 2025-07-01 at 10 38 44 PM" src="https://github.com/user-attachments/assets/f6bad2ae-8dfd-4bc3-b9b9-951ec3acb9a5" />

Tested on Mac
